### PR TITLE
Add financial APIs

### DIFF
--- a/packages/dogyeong/.eslintrc.js
+++ b/packages/dogyeong/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:vue/recommended',
-    '@vue/typescript',
+    'plugin:@typescript-eslint/recommended',
+    '@vue/typescript/recommended',
     '@vue/prettier',
     '@vue/prettier/@typescript-eslint',
   ],
@@ -17,5 +18,6 @@ module.exports = {
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
   },
 };

--- a/packages/dogyeong/package.json
+++ b/packages/dogyeong/package.json
@@ -19,11 +19,13 @@
     "@vue/cli-plugin-typescript": "^4.5.13",
     "common": "1.0.0",
     "cross-env": "^7.0.3",
+    "investing-com-api": "https://github.com/dogyeong/investing-com-api",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.12.10",
     "swiper": "^6.6.1",
     "typescript": "^4.2.4",
     "vue": "^2.6.12",
+    "yahoo-finance": "https://github.com/dogyeong/node-yahoo-finance",
     "zum-portal-core": "1.1.1"
   },
   "devDependencies": {

--- a/packages/dogyeong/src/backend/Server.ts
+++ b/packages/dogyeong/src/backend/Server.ts
@@ -1,16 +1,10 @@
 import 'reflect-metadata';
 import { appContainer } from 'common/backend/AppContainer';
 import * as mongoose from 'mongoose';
+import { mongoConfig } from './config';
 
 mongoose
-  .connect('mongodb://127.0.0.1:27017/investing', {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-    user: 'zum',
-    pass: 'zumdev',
-    authSource: 'admin',
-  })
+  .connect(mongoConfig.uri, mongoConfig.options)
   .then(() => {
     console.log('Connected to MongoDB');
     appContainer.listen();

--- a/packages/dogyeong/src/backend/config/index.ts
+++ b/packages/dogyeong/src/backend/config/index.ts
@@ -1,0 +1,24 @@
+export const authConfig = {
+  googleGrantCodeHeader: 'inv_google_auth',
+  accessTokenCookie: '_inv_access_token_',
+  cookieOptions: {
+    httpOnly: true,
+    maxAge: 24 * 3600 * 1000, // 1 day
+  },
+};
+
+export const jwtConfig = {
+  secret: 'jwtsecretyeah',
+};
+
+export const mongoConfig = {
+  uri: 'mongodb://127.0.0.1:27017/investing',
+  options: {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useFindAndModify: false,
+    user: 'zum',
+    pass: 'zumdev',
+    authSource: 'admin',
+  },
+};

--- a/packages/dogyeong/src/backend/controller/ApiController.ts
+++ b/packages/dogyeong/src/backend/controller/ApiController.ts
@@ -4,6 +4,7 @@ import { Inject } from 'zum-portal-core/backend/decorator/Alias';
 import AuthService from '../service/AuthService';
 import UserService, { GoogleUserInfo, UserInfo } from '../service/UserService';
 import TokenService from '../service/TokenService';
+import MarketService from '../service/MarketService';
 
 const ACCESS_TOKEN_COOKIE_KEY = '_inv_access_token_';
 const GOOGLE_GRANT_CODE_HEADER = 'inv_google_auth';
@@ -18,6 +19,7 @@ export class ApiController {
     @Inject(AuthService) private authService: AuthService,
     @Inject(UserService) private userService: UserService,
     @Inject(TokenService) private tokenService: TokenService,
+    @Inject(MarketService) private marketService: MarketService,
   ) {}
 
   @PostMapping({ path: ['/user'] })
@@ -86,5 +88,16 @@ export class ApiController {
   public logout(req: Request, res: Response) {
     res.clearCookie(ACCESS_TOKEN_COOKIE_KEY);
     res.end();
+  }
+
+  @GetMapping({ path: ['/index'] })
+  public async getIndex(req: Request, res: Response) {
+    this.marketService
+      .getIndices()
+      .then((res) => {
+        console.log(res);
+      })
+      .catch(console.error)
+      .finally(res.end());
   }
 }

--- a/packages/dogyeong/src/backend/controller/ApiController.ts
+++ b/packages/dogyeong/src/backend/controller/ApiController.ts
@@ -94,10 +94,8 @@ export class ApiController {
   public async getIndex(req: Request, res: Response) {
     this.marketService
       .getIndices()
-      .then((res) => {
-        console.log(res);
-      })
+      .then((res) => console.log(res))
       .catch(console.error)
-      .finally(res.end());
+      .finally(() => res.end());
   }
 }

--- a/packages/dogyeong/src/backend/controller/HomeController.ts
+++ b/packages/dogyeong/src/backend/controller/HomeController.ts
@@ -8,7 +8,7 @@ import { HomeFacade } from '../facade/HomeFacade';
 export class HomeController {
   constructor(@Yml('application') private application: any, @Inject(HomeFacade) private homeFacade: HomeFacade) {}
 
-  @GetMapping({ path: ['/'] })
+  @GetMapping({ path: ['/*'] })
   public async getHome(req: Request, res: Response) {
     //탬플릿처리
     await this.homeFacade.renderHtml();

--- a/packages/dogyeong/src/backend/service/MarketService.ts
+++ b/packages/dogyeong/src/backend/service/MarketService.ts
@@ -7,12 +7,12 @@ interface InvestingData {
   value: number;
 }
 
-interface InvestingApiResponse {
+export interface InvestingApiResponse {
   key: string;
   result: InvestingData;
 }
 
-interface CandleChartData {
+export interface CandleChartData {
   date: Date;
   open: number;
   high: number;
@@ -23,8 +23,48 @@ interface CandleChartData {
   symbol: string;
 }
 
+export interface SummaryDetail {
+  summaryDetail: {
+    maxAge: number;
+    priceHint: number;
+    previousClose: number;
+    open: number;
+    dayLow: number;
+    dayHigh: number;
+    regularMarketPreviousClose: number;
+    regularMarketOpen: number;
+    regularMarketDayLow: number;
+    regularMarketDayHigh: number;
+    dividendRate: number;
+    dividendYield: number;
+    exDividendDate: Date;
+    payoutRatio: number;
+    fiveYearAvgDividendYield: number;
+    beta: number;
+    trailingPE: number;
+    forwardPE: number;
+    volume: number;
+    regularMarketVolume: number;
+    averageVolume: number;
+    averageVolume10days: number;
+    averageDailyVolume10Day: number;
+    bid: number;
+    ask: number;
+    bidSize: number;
+    askSize: number;
+    marketCap: number;
+    fiftyTwoWeekLow: number;
+    fiftyTwoWeekHigh: number;
+    priceToSalesTrailing12Months: number;
+    fiftyDayAverage: number;
+    twoHundredDayAverage: number;
+    trailingAnnualDividendRate: number;
+    trailingAnnualDividendYield: number;
+  };
+}
+
 enum Indices {
-  dowJones30 ='indices/us-30',
+  dowJones30 = 'indices/us-30',
   nasdaq100 = 'indices/nq-100',
   snp500 = 'indices/us-spx-500',
   dax = 'indices/germany-30',
@@ -32,7 +72,7 @@ enum Indices {
   cac40 = 'indices/france-40',
   nikkei225 = 'indices/japan-ni225',
   ftseMib = 'indices/it-mib-40',
-};
+}
 
 enum Cryptos {
   btcUsd = 'crypto/bitcoin/btc-usd',
@@ -40,7 +80,7 @@ enum Cryptos {
   bchUsd = 'crypto/bitcoin-cash/bch-usd',
   iotaUsd = 'crypto/iota/iota-usd',
   ltcUsd = 'crypto/litecoin/ltc-usd?c1010798',
-};
+}
 
 enum Stocks {
   apple = 'equities/apple-computer-inc',
@@ -50,18 +90,16 @@ enum Stocks {
 
 @Service()
 export default class MarketService {
-  constructor() {}
-
-  private callInvesting([key, investingId]){ 
+  private callInvesting([key, investingId]) {
     return new Promise<InvestingApiResponse>((resolve, reject) => {
       investing(investingId)
         .then((result) => resolve({ key, result }))
-        .catch(reject)
+        .catch(reject);
     });
   }
 
   /** @TODO 캐싱 적용 */
-  // 지수 
+  // 지수
   public getIndices() {
     return Promise.all(Object.entries(Indices).map(this.callInvesting));
   }
@@ -76,16 +114,16 @@ export default class MarketService {
     return Promise.all(Object.entries(Stocks).map(this.callInvesting));
   }
 
-  // 종목상세 : 52주 변동폭, 일일 변동폭, 거래량(volume), 시가총액(marketcap), 매수가(bid), 매도가(ask), 
-  public getSummaryDetail(symbol): Promise<{}> {
+  // 종목상세 : 52주 변동폭, 일일 변동폭, 거래량(volume), 시가총액(marketcap), 매수가(bid), 매도가(ask),
+  public getSummaryDetail(symbol: string): Promise<SummaryDetail> {
     return yahooFinance.quote({
       symbol,
-      modules: ['summaryDetail']
-    })
+      modules: ['summaryDetail'],
+    });
   }
 
   // 캔들차트 데이터
-  public getCandleChartData(symbol): Promise<CandleChartData[]> {
+  public getCandleChartData(symbol: string): Promise<CandleChartData[]> {
     return yahooFinance.historical({
       symbol,
       from: '2012-01-01',

--- a/packages/dogyeong/src/backend/service/MarketService.ts
+++ b/packages/dogyeong/src/backend/service/MarketService.ts
@@ -1,0 +1,36 @@
+import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import * as yahooFinance from 'yahoo-finance';
+import { investing } from 'investing-com-api';
+
+@Service()
+export default class MarketService {
+  constructor() {}
+
+  public getIndices() {
+    /** historical */
+    // 기간동안의 캔들 데이터
+    // return yahooFinance.historical({
+    //   symbol: 'AAPL',
+    //   from: '2012-01-01',
+    //   to: '2012-12-31',
+    // });
+    /** quote */
+    // "price"
+    // 현재가격에 대한 자세한 정보
+    // 가격변동, 가격변동(퍼센트) ...
+    // return yahooFinance.quote({
+    //   symbol: 'TSLA',
+    //   modules: ['price'],
+    // });
+    // "summaryProfile"
+    // 회사정보(주소,위치,전화번호 등)
+    // "summaryDetail"
+    // 50일 평균, 200일 평균 등...
+
+    return investing('currencies/eur-usd');
+  }
+
+  public getCoins() {}
+
+  public getStocks() {}
+}

--- a/packages/dogyeong/src/backend/service/MarketService.ts
+++ b/packages/dogyeong/src/backend/service/MarketService.ts
@@ -23,6 +23,7 @@ export interface CandleChartData {
   symbol: string;
 }
 
+// 종목상세 : 52주 변동폭, 일일 변동폭, 거래량(volume), 시가총액(marketcap), 매수가(bid), 매도가(ask),
 export interface SummaryDetail {
   summaryDetail: {
     maxAge: number;
@@ -90,6 +91,14 @@ enum Stocks {
 
 @Service()
 export default class MarketService {
+  private getDateString(timeStamp: number) {
+    const date = new Date(timeStamp);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}-${month}-${day}`;
+  }
+
   private callInvesting([key, investingId]) {
     return new Promise<InvestingApiResponse>((resolve, reject) => {
       investing(investingId)
@@ -98,23 +107,18 @@ export default class MarketService {
     });
   }
 
-  /** @TODO 캐싱 적용 */
-  // 지수
   public getIndices() {
     return Promise.all(Object.entries(Indices).map(this.callInvesting));
   }
 
-  // 암호화폐
   public getCoins() {
     return Promise.all(Object.entries(Cryptos).map(this.callInvesting));
   }
 
-  // 주식
   public getStocks() {
     return Promise.all(Object.entries(Stocks).map(this.callInvesting));
   }
 
-  // 종목상세 : 52주 변동폭, 일일 변동폭, 거래량(volume), 시가총액(marketcap), 매수가(bid), 매도가(ask),
   public getSummaryDetail(symbol: string): Promise<SummaryDetail> {
     return yahooFinance.quote({
       symbol,
@@ -122,13 +126,14 @@ export default class MarketService {
     });
   }
 
-  // 캔들차트 데이터
   public getCandleChartData(symbol: string): Promise<CandleChartData[]> {
+    const currentTimeStamp = Date.now();
+    const lastYearTimeStamp = currentTimeStamp - 1000 * 3600 * 24 * 365;
+
     return yahooFinance.historical({
       symbol,
-      from: '2012-01-01',
-      to: '2012-12-31',
-      // period: 'd'  // 'd' (daily), 'w' (weekly), 'm' (monthly), 'v' (dividends only)
+      from: this.getDateString(currentTimeStamp),
+      to: this.getDateString(lastYearTimeStamp),
     });
   }
 }

--- a/packages/dogyeong/src/backend/service/TokenService.ts
+++ b/packages/dogyeong/src/backend/service/TokenService.ts
@@ -1,21 +1,19 @@
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import * as jwt from 'jsonwebtoken';
-
-const JWT_SECRET = 'jwtsecretyeah';
+import { jwtConfig } from '../config';
+import { UserInfo, GoogleUserInfo } from './UserService';
 
 @Service()
 export default class TokenService {
-  constructor() {}
-
-  public createToken(payload: string | object) {
+  public createToken(payload: string | UserInfo | GoogleUserInfo) {
     if (!payload) throw new Error('invalid payload');
 
-    return jwt.sign(payload, JWT_SECRET);
+    return jwt.sign(payload, jwtConfig.secret);
   }
 
   public verifyToken(token: string) {
     if (!token) throw new Error('invalid token');
 
-    return jwt.verify(token, JWT_SECRET);
+    return jwt.verify(token, jwtConfig.secret);
   }
 }

--- a/packages/dogyeong/src/backend/service/UserService.ts
+++ b/packages/dogyeong/src/backend/service/UserService.ts
@@ -18,8 +18,6 @@ export interface UserInfo {
 
 @Service()
 export default class UserService {
-  constructor() {}
-
   public async getUserByEmailAndPassword({ email, password }) {
     const user = await User.findOne({ email, password }).lean<UserInfo>();
     return user;

--- a/packages/dogyeong/tsconfig.json
+++ b/packages/dogyeong/tsconfig.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "allowJs": true
+    "allowJs": true,
+    "lib": ["esnext"]
   },
 
   "exclude": ["**/frontend/**", "**/node_modules/**"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,7 +2780,7 @@ aws4@^1.8.0:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
+axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
@@ -3114,7 +3114,7 @@ bluebird@3.5.1:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
-bluebird@^3.1.1, bluebird@^3.5.1, bluebird@^3.5.5:
+bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6715,6 +6715,12 @@ invariant@^2.2.2, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+"investing-com-api@https://github.com/dogyeong/investing-com-api":
+  version "2.2.2"
+  resolved "https://github.com/dogyeong/investing-com-api#d85af7a1c1225e0e42501add76b44bf95dc7c72b"
+  dependencies:
+    axios "^0.21.0"
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -8651,7 +8657,7 @@ lodash.uniq@^4.5.0:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.7.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9077,14 +9083,14 @@ mkdirp@^1.0.4:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment-timezone@^0.5.31:
+moment-timezone@^0.5.10, moment-timezone@^0.5.31:
   version "0.5.33"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
   integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.17.1:
   version "2.29.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -11063,7 +11069,17 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.7, request-promise-na
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.55.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request-promise@^4.2.1:
+  version "4.2.6"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
+  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.4"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request@^2.55.0, request@^2.79.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -12052,6 +12068,11 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string@^3.3.3:
+  version "3.3.3"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
+  integrity sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=
+
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -12470,7 +12491,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@^2.2.0, tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
+tough-cookie@^2.2.0, tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -13571,6 +13592,20 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+"yahoo-finance@https://github.com/dogyeong/node-yahoo-finance":
+  version "0.3.7"
+  resolved "https://github.com/dogyeong/node-yahoo-finance#f2a1758e9a944d2371a696ef7bbbd999855c7a81"
+  dependencies:
+    bluebird "^3.4.6"
+    debug "^2.3.3"
+    lodash "^4.17.2"
+    moment "^2.17.1"
+    moment-timezone "^0.5.10"
+    request "^2.79.0"
+    request-promise "^4.2.1"
+    string "^3.3.3"
+    tough-cookie "^2.3.2"
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## 작업내용

- 금융 api 라이브러리 추가 및 적용
  - [investing-com-api](https://github.com/dogyeong/investing-com-api)
  - [node-yahoo-finance](https://github.com/dogyeong/node-yahoo-finance)
  - 적용해보니 SSL 에러가 발생해서 라이브러리의 저장소를 fork한 후, 에러를 무시하도록 수정하여 사용
- 금융 api 구현을 위한 `MarketService`, 라우팅 추가
  - `/api/indices` : 여러 지수들의 1년간의 가격
  - `/api/coins` : 여러 가상화폐들의 1년간의 가격
  - `/api/stocks` : 여러 주식들의 1년간의 가격
  - `/api/summary` : 특정 주식의 요약정보
  - `/api/chart` : 특정 주식의 캔들차트 데이터
- eslintrc 수정
  - TypeScript, Prettier와 통합이 제대로 안되어서 eslintrc 파일을 수정하여 정상적으로 적용