### PR TITLE
Refactor: Chart-Polygon logic 분리

### DIFF
--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
        * @description
        * 기본 limit 120일 데이터 요청하지만, 휴장일 데이터 제외하고 가져오므로 넉넉하게 200일 요청
        */
-      default: getDateString(Date.now() - 250 * 3600 * 24 * 1000),
+      default: getDateString(Date.now() - 500 * 3600 * 24 * 1000),
     },
     to: {
       type: [String, Number, Date],
@@ -52,10 +52,10 @@ export default Vue.extend({
         Object.freeze({
           /**
            * @description
-           * 가장 최근 시세부터 호출하기 위해 sort-desc
+           * 가장 최근 시세부터 호출하기 위해 sort-asc
            */
           sort: 'asc',
-          limit: 150,
+          limit: 300,
         }),
     },
   },
@@ -91,12 +91,18 @@ export default Vue.extend({
   async mounted() {
     const chart = this.$refs.canvas;
     this.ctx = chart.getContext('2d') as CanvasRenderingContext2D;
+
+    /**@todo console 삭제 */
+    const timerLabel = `api-chart timer`;
+    console.warn(timerLabel);
+    console.time(timerLabel);
     try {
       await this.getStockData(this.options);
       this.getChart(this.options);
     } catch (e) {
       console.error(e);
     }
+    console.timeEnd(timerLabel);
   },
 
   /**

--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -1,11 +1,5 @@
 <template>
-  <section class="area">
-    <p>
-      <b>{{ typeName.toUpperCase() }}</b
-      >: {{ ticker }}
-    </p>
-    <canvas ref="canvas" class="area"></canvas>
-  </section>
+  <canvas ref="canvas" class="area"></canvas>
 </template>
 
 <script lang="ts">
@@ -13,17 +7,15 @@
  * @description
  * Chart wrapper
  */
-import polygon from '@/services/chart/polygon';
-import { GetMultiDaysStockProps, TimespanEnum } from '@/type/apis';
+import { ChartModuleMapperEnums } from '@/store/types';
+import { TimespanEnum } from '@/type/apis';
+import { MultidaysStockData } from '@/type/chart';
 import { drawBasicCandleChart } from '@/utils/chart/candle';
 import { getDateString } from '@/utils/date';
 import Vue from 'vue';
+import { mapActions, mapGetters } from 'vuex';
 
 export default Vue.extend({
-  /**
-   * @todo
-   * 다듬으면서 default는 삭제 예정
-   */
   props: {
     typeName: {
       type: String,
@@ -46,10 +38,8 @@ export default Vue.extend({
       /**
        * @description
        * 기본 limit 120일 데이터 요청하지만, 휴장일 데이터 제외하고 가져오므로 넉넉하게 200일 요청
-       * @todo
-       * 좀더 빠르게 일자 계산할 수 있는 방법?
        */
-      default: getDateString(Date.now() - 400 * 3600 * 24 * 1000),
+      default: getDateString(Date.now() - 250 * 3600 * 24 * 1000),
     },
     to: {
       type: [String, Number, Date],
@@ -65,20 +55,31 @@ export default Vue.extend({
            * 가장 최근 시세부터 호출하기 위해 sort-desc
            */
           sort: 'asc',
-          limit: 300,
+          limit: 150,
         }),
     },
   },
+
   /**
    * 차트 데이터 저장
    */
   data() {
     return {
       onReady: false,
-      stocksPromise: null,
-      candles: [],
-      candlesCount: 0,
+      ctx: null,
+      options: {
+        ticker: this.ticker,
+        multiplier: this.multiplier,
+        timespan: this.timespan,
+        from: this.from,
+        to: this.to,
+        query: this.query,
+      },
     };
+  },
+
+  computed: {
+    ...mapGetters([ChartModuleMapperEnums.getterCheckStockLoaded]),
   },
 
   /**
@@ -87,54 +88,43 @@ export default Vue.extend({
    * API fetching
    * make chart
    */
-  mounted() {
-    /**
-     * @todo
-     * - Canvas 자체를 상하반전 시킬 수 있는 방법,,
-     */
+  async mounted() {
     const chart = this.$refs.canvas;
-    const ctx = chart.getContext('2d') as CanvasRenderingContext2D;
-
-    const { ticker, multiplier, timespan, from, to, query } = this;
-    const config = {
-      ticker,
-      multiplier,
-      timespan,
-      from,
-      to,
-      query,
-    } as GetMultiDaysStockProps;
-
-    /**
-     * 동일 요청에 대한 caching
-     * - 1분 단위
-     */
-    const limit = query.limit;
-    const storageKey = `${ticker}-${multiplier}${timespan}-${limit}-${new Date(Date.now()).getMinutes()}`;
-    const cached = sessionStorage.getItem(storageKey);
-
-    if (cached) {
-      this.onReady = true;
-      console.info(`using cached data`);
-      const { results, limit, resultsCount } = JSON.parse(cached);
-      drawBasicCandleChart({ ctx, results, limit, resultsCount });
-      return;
+    this.ctx = chart.getContext('2d') as CanvasRenderingContext2D;
+    try {
+      await this.getStockData(this.options);
+      this.getChart(this.options);
+    } catch (e) {
+      console.error(e);
     }
+  },
 
-    polygon
-      .getMultiDaysStockData(config)
-      .then(({ results, resultsCount }) => {
-        console.info(`data fetched`);
+  /**
+   * @todo
+   * SSR creat chart
+   */
+  // serverPrefetch() {
+  //   const { getStockData } = getModule(Chart);
+  //   const options = this.$props.options;
+  //   return getStockData(options).then(/** @todo */);
+  // },
 
-        this.onReady = true;
-
-        drawBasicCandleChart({ ctx, results, limit, resultsCount });
-
-        return { results, resultsCount, limit };
-      })
-      .then((data) => {
-        sessionStorage.setItem(storageKey, JSON.stringify(data));
-      });
+  /**
+   * @todo
+   *
+   * Component에서 비동기 작업은 SSR build 과정에서 계속 에러
+   * 일반적인 example 따라서 Vuex store로 이동..
+   * 했는데 그래도 에러...
+   * 일단은 CSR 위주로 작업하고
+   * 추후 Backend에서 데이터 넘겨주는 방식으로 변경 예정
+   */
+  methods: {
+    ...mapActions([ChartModuleMapperEnums.actionGetStockData]),
+    getChart(options) {
+      const { results, resultsCount, dataKey } = this[ChartModuleMapperEnums.getterCheckStockLoaded] as MultidaysStockData;
+      drawBasicCandleChart({ ctx: this.ctx, limit: options.query.limit, results, resultsCount });
+      this.onReady = true;
+    },
   },
 });
 </script>

--- a/packages/wiii/frontend/services/chart/polygon.ts
+++ b/packages/wiii/frontend/services/chart/polygon.ts
@@ -1,10 +1,10 @@
 import { polygonAPIKey } from '@/config/index';
 import { GetMultiDaysStockProps } from '@/type/apis';
-import { getDateString } from '@/utils/date';
-import { IAggResponseFormatted, ICryptoClient, IStocksClient, restClient } from '@polygon.io/client-js';
+import { MultidaysStockData } from '@/type/chart';
+import { ICryptoClient, IStocksClient, restClient } from '@polygon.io/client-js';
 
 /**
- * @classdesc
+ * @class
  * polygon.io RESTful API를 사용해 주가, Crypto 시세 및 종목정보 데이터 가져오는 class
  * - free-tier 관련 API만 활용
  */
@@ -37,18 +37,19 @@ class PolygonAPI {
    * - https://polygon.io/docs/get_v2_aggs_ticker__stocksTicker__range__multiplier___timespan___from___to__anchor
    * - https://github.com/polygon-io/client-js/blob/master/src/rest/stocks/aggregates.ts
    */
-  public async getMultiDaysStockData(props: GetMultiDaysStockProps) {
-    const { ticker, multiplier, timespan, from, to = getDateString(), query } = props;
+  public async getMultiDaysStockData(props: GetMultiDaysStockProps): Promise<MultidaysStockData> {
+    const { ticker, multiplier, timespan, from, to, query } = props;
     if (!ticker) return;
     try {
       const { results, resultsCount } = await this.stocks.aggregates(ticker, multiplier, timespan, from, to, query);
 
+      const dataKey = `${ticker}-${multiplier}${timespan}-${new Date().getMinutes()}`;
       /**
        * @todo
        * 예외 처리 또는 추가 로직?
        */
 
-      return { results, resultsCount };
+      return { dataKey, results, resultsCount };
     } catch (e) {
       console.error(e);
       return;

--- a/packages/wiii/frontend/store/index.ts
+++ b/packages/wiii/frontend/store/index.ts
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 
 import { views } from '@/type/views';
 import { actionTypes } from '@/store/types';
+import chart from '@/store/modules/chart';
 
 Vue.use(Vuex);
 
@@ -21,5 +22,7 @@ export default () =>
         return context.commit(actionTypes.setCurrentView, selectedView);
       },
     },
-    modules: {},
+    modules: {
+      chart,
+    },
   });

--- a/packages/wiii/frontend/store/modules/chart.ts
+++ b/packages/wiii/frontend/store/modules/chart.ts
@@ -1,0 +1,36 @@
+import Polygon from '@/services/chart/polygon';
+import { ChartDataEnums } from '@/store/types';
+import { GetMultiDaysStockProps } from '@/type/apis';
+import { MultidaysStockData } from '@/type/chart';
+import { Module, MutationAction, VuexModule } from 'vuex-module-decorators';
+
+@Module
+export default class Chart extends VuexModule {
+  public stockData: MultidaysStockData = {};
+  public isStockLoaded: boolean = false;
+  public indexData: Object = {};
+  public coinData: Object = {};
+
+  get loadedStockData() {
+    return this.stockData;
+  }
+
+  /**
+   * @todo
+   * - dataKey 활용해 caching, 이전 데이터 삭제
+   * - action - mutations 분리
+   */
+  @MutationAction
+  public async getStockData(options: GetMultiDaysStockProps) {
+    try {
+      const { results, resultsCount, dataKey } = await Polygon.getMultiDaysStockData(options);
+      if (!results || resultsCount === 0) throw new Error('No Stocks Results from Polygon');
+      const result = { [ChartDataEnums.stockData]: { results, resultsCount, dataKey } };
+      this.isStockLoaded = true;
+      return result;
+    } catch (e) {
+      console.error(e);
+      return;
+    }
+  }
+}

--- a/packages/wiii/frontend/store/types.ts
+++ b/packages/wiii/frontend/store/types.ts
@@ -1,3 +1,15 @@
 export enum actionTypes {
   setCurrentView = 'setCurrentView',
 }
+
+export enum ChartDataEnums {
+  stockData = 'stockData',
+  coinData = 'coinData',
+  indexData = 'indexData',
+}
+
+export enum ChartModuleMapperEnums {
+  stateIsStockLoaded = 'isStockLoaded',
+  actionGetStockData = 'getStockData',
+  getterCheckStockLoaded = 'loadedStockData',
+}

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -16,7 +16,13 @@ export interface BasicCandleOptionProps {
   high: number;
   width: number;
   height: number;
-  timestamp?: string;
+  timestamp?: number;
+
+  highest: number;
+  lowest: number;
+  canvasWidth?: number;
+  canvasHeight?: number;
+  hRatio: number;
 }
 
 export interface DrawCandleChartOptions {

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -1,0 +1,33 @@
+import { IAggV2Formatted } from '@polygon.io/client-js/lib/rest/stocks/aggregates';
+
+export interface MultidaysStockData {
+  dataKey?: string;
+  results?: IAggV2Formatted[];
+  resultsCount?: number;
+}
+
+export interface BasicCandleOptionProps {
+  ctx: CanvasRenderingContext2D;
+  x: number;
+  y: number;
+  open: number;
+  close: number;
+  low: number;
+  high: number;
+  width: number;
+  height: number;
+  timestamp?: string;
+}
+
+export interface DrawCandleChartOptions {
+  ctx: CanvasRenderingContext2D;
+  results: IAggV2Formatted[];
+  resultsCount: number;
+  limit: number;
+}
+
+export enum CandleColorEnum {
+  up = 'red',
+  down = 'blue',
+  same = 'black',
+}

--- a/packages/wiii/package.json
+++ b/packages/wiii/package.json
@@ -24,6 +24,7 @@
     "typeorm": "^0.2.32",
     "typescript": "^4.2.4",
     "vue": "^2.6.12",
+    "vuex-module-decorators": "^1.0.1",
     "zum-portal-core": "1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Feat: CandleChart 세로 비율 조정

![image](https://user-images.githubusercontent.com/57997672/119664577-71365c00-be6e-11eb-86e1-bcaefd2b31a5.png)

- CanvasHeight / (highest price - lowest price) 을 ratio로 두고 세로 길이 조정
- 정확하게 세로폭에 맞지는 않아서 좀더 조정해야 함

![image](https://user-images.githubusercontent.com/57997672/119664631-7e534b00-be6e-11eb-9352-7fd10450be8f.png)

- canvas 로직 추가되고, vuex 거치면서 전반적인 loading 시간은 길어짐
  - 클릭하고 들어갔을 때 바로 체감상 1초 정도 안보이는 것이 느껴지는 정도

## Refactor: Chart-Polygon logic 분리

- Chart.vue mounted에 있던 api 호출로직, canvas 생성 로직 이동
  - 비동기로직은 Vuex mutation으로 이동
  - Vuex module은 `vuex-module-decorators` 활용해 구현

## TODO

- SSR build 여전히 안되는 문제
  - polygon type 문제인지 잘 모르겠음
  - 추후 api server에서 작업 후 client에서 fetch/axios로 가져오는 방식으로 변경 예정