### PR TITLE
Feat: CandleChart 일자구분선, 가격구분선, 이동평균선 추가, 멀티차트 테스트

### DIFF
--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -37,7 +37,8 @@ export default Vue.extend({
       type: [String, Date],
       /**
        * @description
-       * 기본 limit 120일 데이터 요청하지만, 휴장일 데이터 제외하고 가져오므로 넉넉하게 200일 요청
+       * 휴장일 데이터 제외하고 가져오므로
+       * 기본 limit 보다 넉넉하게 요청
        */
       default: getDateString(Date.now() - 500 * 3600 * 24 * 1000),
     },
@@ -52,10 +53,10 @@ export default Vue.extend({
         Object.freeze({
           /**
            * @description
-           * 가장 최근 시세부터 호출하기 위해 sort-asc
+           * 가장 최근 시세부터 호출하기 위해 sort-desc
            */
-          sort: 'asc',
-          limit: 300,
+          sort: 'desc',
+          limit: 200,
         }),
     },
   },
@@ -137,6 +138,8 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 canvas {
+  width: 600px;
+  height: 300px;
   padding: 15px;
   box-shadow: 0 0 20px 5px $red-neon;
 }

--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -9,7 +9,7 @@
  */
 import { ChartModuleMapperEnums } from '@/store/types';
 import { TimespanEnum } from '@/type/apis';
-import { MultidaysStockData } from '@/type/chart';
+import { MultidaysStockData, CanvasOptionEnum } from '@/type/chart';
 import { drawBasicCandleChart } from '@/utils/chart/candle';
 import { getDateString } from '@/utils/date';
 import Vue from 'vue';
@@ -91,7 +91,7 @@ export default Vue.extend({
    */
   async mounted() {
     const chart = this.$refs.canvas;
-    this.ctx = chart.getContext('2d') as CanvasRenderingContext2D;
+    this.ctx = chart.getContext(CanvasOptionEnum.context2d, { alpha: 1 }) as CanvasRenderingContext2D;
 
     /**@todo console 삭제 */
     const timerLabel = `api-chart timer`;
@@ -141,6 +141,8 @@ canvas {
   width: 600px;
   height: 300px;
   padding: 15px;
+  margin: 20px;
   box-shadow: 0 0 20px 5px $red-neon;
+  background-color: white;
 }
 </style>

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -6,23 +6,26 @@ export interface MultidaysStockData {
   resultsCount?: number;
 }
 
+/** @todo 개발 편의 위해 일단 모두 optional로 지정 */
 export interface BasicCandleOptionProps {
   ctx: CanvasRenderingContext2D;
-  x: number;
-  y: number;
-  open: number;
-  close: number;
-  low: number;
-  high: number;
-  width: number;
-  height: number;
-  timestamp?: number;
+  idx?: number;
+  x?: number;
+  y?: number;
+  open?: number;
+  close?: number;
+  low?: number;
+  high?: number;
+  bodyWidth?: number;
+  height?: number;
+  timestamp?: Date;
 
-  highest: number;
-  lowest: number;
+  highest?: number;
+  lowest?: number;
   canvasWidth?: number;
   canvasHeight?: number;
-  hRatio: number;
+  hRatio?: number;
+  padding?: number;
 }
 
 export interface DrawCandleChartOptions {
@@ -33,7 +36,9 @@ export interface DrawCandleChartOptions {
 }
 
 export enum CandleColorEnum {
-  up = 'red',
-  down = 'blue',
-  same = 'black',
+  up = 'rgba(255, 23, 68, 1)',
+  down = 'rgba(33, 150, 243, 1)',
+  same = 'rgba(97, 97, 97, 1)',
+  partition = `rgba(224, 224, 224, 1)`,
+  grey900 = `rgba(33, 33, 33, 1)`,
 }

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -35,10 +35,44 @@ export interface DrawCandleChartOptions {
   limit: number;
 }
 
+export enum CanvasOptionEnum {
+  context2d = `2d`,
+  textAlignRight = `right`,
+  textAlignLeft = `left`,
+  textBaseAlphabetic = `alphabetic`,
+  textBaseTop = `top`,
+  globalCompositeOperation = `destination-over`,
+}
+
 export enum CandleColorEnum {
   up = 'rgba(255, 23, 68, 1)',
   down = 'rgba(33, 150, 243, 1)',
   same = 'rgba(97, 97, 97, 1)',
   partition = `rgba(224, 224, 224, 1)`,
   grey900 = `rgba(33, 33, 33, 1)`,
+}
+
+export enum MAColorEnum {
+  red500 = `rgba(244, 67, 54, 0.5)`,
+  green500 = `rgba(0, 150, 136, 0.5)`,
+  blue500 = `rgba(33, 150, 243, 0.5)`,
+  grey500 = `rgba(158, 158, 158, 0.5)`,
+}
+
+/**
+ * setSMA 단순이동평균선 Option
+ * @property `data` 조정된 종가, 캔들 중앙값 데이터
+ * @property `duration`? 평균낼 기간, default 20
+ * @property `color` 이동평균선 색
+ * @property `hRatio` 비율
+ * @property `duration` 평균 기간
+ */
+export interface SetSMAOptions {
+  data: Array<{
+    adjClose: number;
+    candleCenter: number;
+  }>;
+  color: string;
+  hRatio: number;
+  duration: number;
 }

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -59,19 +59,20 @@ export enum MAColorEnum {
   grey500 = `rgba(158, 158, 158, 0.5)`,
 }
 
+export type adjustedData = {
+  adjClose: number;
+  candleCenter: number;
+}[];
+
 /**
  * setSMA 단순이동평균선 Option
  * @property `data` 조정된 종가, 캔들 중앙값 데이터
  * @property `duration`? 평균낼 기간, default 20
  * @property `color` 이동평균선 색
  * @property `hRatio` 비율
- * @property `duration` 평균 기간
  */
 export interface SetSMAOptions {
-  data: Array<{
-    adjClose: number;
-    candleCenter: number;
-  }>;
+  data: adjustedData;
   color: string;
   hRatio: number;
   duration: number;

--- a/packages/wiii/frontend/utils/chart/candle.ts
+++ b/packages/wiii/frontend/utils/chart/candle.ts
@@ -1,69 +1,175 @@
 import { BasicCandleOptionProps, CandleColorEnum, DrawCandleChartOptions } from '@/type/chart';
 
+const { PI, min, abs } = Math;
+
+const BASE_RADIAN = PI / 180;
+
+/**
+ * adjustedY 세로y 위치 조정 함수, 구간 최저가 기준
+ * @param base 구간 최저가 또는 최하단 라인
+ * @param hRatio 높이 비율
+ * @param origins ex. `[open, close, low, high]`
+ * @returns rest 순서대로 조정된 높이값 배열
+ */
+
+const adjustY = (base: number) => (hRatio: number) => (origins: number[]): number[] => origins.map((n) => (-n + base) * hRatio);
+
+/**
+ * setColor
+ * @todo 나중에 사용자가 customizing할 수 잇도록?
+ * @param o open
+ * @param c close
+ * @returns colorString
+ */
 const setColor = (o: number, c: number) => {
   if (o === c) return CandleColorEnum.same;
   if (o > c) return CandleColorEnum.down;
   if (o < c) return CandleColorEnum.up;
 };
 
-const BASE_RADIAN = Math.PI / 180;
+/**
+ * setPricePartition
+ * 좌상단 (0,0)에서 시작
+ * @param ctx
+ * @param lowest 구간 최저가
+ * @param highest 구간 최고가
+ * @param canvasWidth 캔버스 영역
+ */
+const setPricePartition = (
+  ctx: CanvasRenderingContext2D,
+  hRatio?: number,
+  partitionNum?: number,
+  hRange?: number,
+  canvasWidth?: number,
+  canvasHeight?: number,
+  lowest?: number,
+  padding?: number,
+) => {
+  ctx.save();
+  const ratio = hRange / partitionNum;
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = CandleColorEnum.partition;
+  ctx.fillStyle = CandleColorEnum.grey900;
+  ctx.font = `italic 20px sans-serif`;
+  ctx.textAlign = 'right';
 
+  // const partitionYs = adjustY(lowest - padding)(hRatio)([...Array(partitionNum+1).keys()].map(n => -(n*ratio)*))
+
+  for (let n = partitionNum + 1; n--; ) {
+    /** 구분선 */
+    const curH = -(n * ratio) * hRatio;
+    ctx.beginPath();
+    ctx.moveTo(0, curH);
+    ctx.lineTo(-canvasWidth, curH);
+    ctx.closePath();
+    ctx.stroke();
+
+    /** 구분선 가격 */
+    ctx.fillText((lowest - curH / hRatio).toFixed(2).toString(), 0, curH);
+  }
+  ctx.restore();
+};
+
+/**
+ * 기본 캔들차트 생성
+ *
+ * @param BasicCandleOptionProps
+ *
+ * @todo
+ * 기능별 함수 분리
+ */
 const basicCandle = ({
   ctx,
-  x,
-  y,
+  idx,
   high,
   low,
   open,
   close,
-  width,
-  height,
+  bodyWidth,
   timestamp,
   highest,
   lowest,
   canvasWidth,
   canvasHeight,
   hRatio,
+  padding,
 }: BasicCandleOptionProps) => {
+  /** @description  기본 설정 */
   const color = setColor(open, close);
-  ctx.strokeStyle = color;
-  ctx.fillStyle = color;
-  ctx.save();
-  ctx.translate(0, canvasHeight);
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'alphabetic';
+  ctx.font = `20px sans-serif`;
 
-  ctx.strokeText('기준', 0, 0);
   /**
    * @todo
    * 비율 맞추기
-   * - canvasHeight에 따라 ratio 변화되어야 함
    */
-  ctx.fillRect(x, (-y - height + lowest * 0.8) * hRatio, width, height * hRatio);
 
-  const lineCenter = x + width / 2;
-  ctx.lineWidth = 1;
+  /** @description text 위치 조정 */
+  const dateHeight = 0,
+    // monthHeight = 18,
+    textBase = -2,
+    textHRatio = 1;
+  const adjustTextY = (origins: number[]): number[] => adjustY(textBase)(textHRatio)(origins);
+  const [adjDayH] = adjustTextY([dateHeight]);
+
+  /** @description 캔들 위치 조정 */
+  const adjustCandleY = (origins: number[]): number[] => adjustY(lowest)(/** hRatio */ 1)(origins);
+  /** @constant adjX adjusted X, 오른쪽부터 최신순 */
+  const adjX = -idx * bodyWidth - 30;
+  const [adjOpen, adjClose, adjLow, adjHigh] = adjustCandleY([open, close, low, high]);
+  const bodyHeight = adjClose - adjOpen;
+  ctx.save();
+
+  /** @description 일자구분선 */
+
+  const dateX = adjX + bodyWidth;
+
+  if (idx % 5 === 0) {
+    ctx.lineWidth = 1;
+    if (idx % 10 === 0) ctx.lineWidth = 5;
+    ctx.strokeStyle = CandleColorEnum.partition;
+    ctx.beginPath();
+    ctx.moveTo(dateX, 0);
+    ctx.lineTo(dateX, -canvasHeight);
+    ctx.closePath();
+    ctx.stroke();
+  }
+
+  /** @description 일자구분선 월/일 표시 */
+  ctx.fillStyle = CandleColorEnum.grey900;
+  const [curDate, curMonth] = [timestamp.getDate(), timestamp.getMonth()];
+  if (idx % 10 === 0) ctx.fillText(`${(curMonth + 1).toString()} / ${curDate.toString()}`, dateX, adjDayH);
+  ctx.restore();
+  ctx.save();
+
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.scale(1, hRatio);
+
+  /** @description 캔들 몸통 */
+  const bodyWidthRatio = 0.8;
+  ctx.fillRect(adjX, adjOpen, bodyWidth * bodyWidthRatio, bodyHeight);
+
+  /** @description 캔들 꼬리 */
+  const lineCenter = adjX + (bodyWidth * bodyWidthRatio) / 2;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = color;
   ctx.beginPath();
-  ctx.moveTo(lineCenter, (+lowest * 0.8 - low) * hRatio);
-  ctx.lineTo(lineCenter, (lowest * 0.8 - high) * hRatio);
+  ctx.moveTo(lineCenter, adjLow);
+  ctx.lineTo(lineCenter, adjHigh);
   ctx.closePath();
   ctx.stroke();
 
-  /**
-   * @todo
-   * 일자
-   */
-  // ctx.textAlign = 'center';
-  // ctx.fillText(String(timestamp), x, -30);
   ctx.restore();
 };
 
 /**
- * @todo
- * - width: 캔들 1개 너비 = 전체 canvas width / 캔들 갯수
- * - x: width * index
- * - y: ??
- * - height: ??
+ * drawBasicCandleChart
+ * @param DrawCandleChartOptions
+ * @returns base64 문자열
  */
-export const drawBasicCandleChart = ({ ctx, results, resultsCount, limit }: DrawCandleChartOptions) => {
+export const drawBasicCandleChart = ({ ctx, results, resultsCount, limit }: DrawCandleChartOptions): string => {
   const timerLabel = `draw Chart`;
   console.warn(timerLabel);
   console.time(timerLabel);
@@ -73,49 +179,66 @@ export const drawBasicCandleChart = ({ ctx, results, resultsCount, limit }: Draw
    * 캔버스 dpi 강제로 높이기
    * 변수화 필요..
    */
-  const canvasWidth = (ctx.canvas.width = 1200);
-  const canvasHeight = (ctx.canvas.height = 600);
-  ctx.canvas.style.width = `${canvasWidth / 2}px`;
-  ctx.canvas.style.height = `${canvasHeight / 2}px`;
+  const cvs = ctx.canvas;
+  const padding = 10;
+  const canvasWidth = (cvs.width = window.screenX * 3);
+  const canvasHeight = (cvs.height = 900);
+  cvs.style.width = `${canvasWidth / 3}px`;
+  cvs.style.height = `${canvasHeight / 3}px`;
+  cvs.style.padding = `${padding}px`;
+  cvs.style.overflow = 'auto';
+  ctx.textBaseline = `top`;
+
+  /** @constant numToShow 현재 화면에 보여지는 캔들 갯수  */
+  const numToShow = min(resultsCount, limit);
+  const showingData = results.slice(0, numToShow + 1);
 
   let highest = 0,
     lowest = Number.MAX_SAFE_INTEGER;
 
-  for (const { h, l } of results) {
+  for (const { h, l } of showingData) {
     if (highest < h) highest = h;
     if (lowest > l) lowest = l;
   }
 
-  const numToShow = Math.min(resultsCount, limit);
-  // const numToShow = 50;
-  const w = canvasWidth / numToShow;
-  const hRatio = canvasHeight / (highest - lowest);
+  /** @constant bodyWidth 캔들바디 너비 */
+  const bodyWidth = canvasWidth / numToShow;
 
-  for (let i = 0, cnt = numToShow; cnt--; ) {
-    const { close, low, open, high, timestamp } = results[i++];
+  const hRange = highest - lowest;
+
+  /** @constant 높이 비율, 전체 캔들데이터 최고가-최저가 구간으로 조정 */
+  const hRatio = canvasHeight / hRange;
+
+  /** @description 계산 편리 위해 우하단으로 이동 */
+  ctx.translate(canvasWidth, canvasHeight);
+
+  /**@todo 가격 구분선 */
+  const partitionNum = 5;
+  setPricePartition(ctx, hRatio, partitionNum, hRange, canvasWidth, canvasHeight, lowest, padding);
+
+  let idx = 0;
+  for (const day of showingData) {
+    const { close, low, open, high, timestamp } = day;
     basicCandle({
       ctx,
-      x: i * w + 1,
-      y: open,
+      idx: idx++,
       open,
       close,
       low,
       high,
-      width: w * 0.8,
-      height: Math.abs(close - open),
-      timestamp: new Date(timestamp).getDate(),
+      bodyWidth,
+      timestamp: new Date(timestamp),
       canvasWidth,
       canvasHeight,
       highest,
       lowest,
       hRatio,
+      padding,
     });
   }
 
-  /**
-   * @todo
-   * - base64로 store 저장, caching
-   */
-  // ctx.canvas.toDataURL('image/png', 1);
   console.timeEnd(timerLabel);
+
+  /**@description base64 이미지로 저장해, caching */
+  return ctx.canvas.toDataURL('image/png', 1);
 };

--- a/packages/wiii/frontend/utils/chart/candle.ts
+++ b/packages/wiii/frontend/utils/chart/candle.ts
@@ -1,9 +1,10 @@
 import { BasicCandleOptionProps, CandleColorEnum, CanvasOptionEnum, DrawCandleChartOptions, MAColorEnum } from '@/type/chart';
 import { setSMA } from './sma';
 
-const { PI, min, abs } = Math;
+const { PI, min } = Math;
 
-const BASE_RADIAN = PI / 180;
+/** @description ctx.rotate() 사용시 필요 */
+// const BASE_RADIAN = PI / 180;
 
 /**
  * adjustedY 세로y 위치 조정 함수, 구간 최저가 기준
@@ -13,7 +14,7 @@ const BASE_RADIAN = PI / 180;
  * @returns rest 순서대로 조정된 높이값 배열
  */
 
-const adjustY = (base: number) => (hRatio: number) => (origins: number[]): number[] => origins.map((n) => (-n + base) * hRatio);
+const adjustY = (base: number, hRatio: number, origins: number[]): number[] => origins.map((n) => (-n + base) * hRatio);
 
 /**
  * setColor
@@ -31,10 +32,14 @@ const setColor = (o: number, c: number) => {
 /**
  * setPricePartition
  * 좌상단 (0,0)에서 시작
- * @param ctx
+ * @param ctx CanvasContext
+ * @param partitionNum 가격 구분 개수
+ * @param hRatio 비율 조정
+ * @param hRange 가격구간 높이
+ * @param canvasWidth 캔버스 너비
+ * @param canvasHeight 캔버스 높이
  * @param lowest 구간 최저가
- * @param highest 구간 최고가
- * @param canvasWidth 캔버스 영역
+ * @param padding Canvas Padding
  */
 const setPricePartition = (
   ctx: CanvasRenderingContext2D,
@@ -76,6 +81,8 @@ const setPricePartition = (
  *
  * @todo
  * 기능별 함수 분리
+ * 비율 맞추기
+ * scale 조정 없이 절대값으로 변경 - 이평선 굵기 및 해상도 문제
  */
 const basicCandle = ({
   ctx,
@@ -95,26 +102,18 @@ const basicCandle = ({
 }: BasicCandleOptionProps) => {
   /** @description  기본 설정 */
   const color = setColor(open, close);
-
   ctx.globalCompositeOperation = CanvasOptionEnum.globalCompositeOperation;
-
-  /**
-   * @todo
-   * 비율 맞추기
-   */
 
   /** @description text 위치 조정 */
   const dateHeight = 0,
     textBase = -2,
     textHRatio = 1;
-  const adjustTextY = (origins: number[]): number[] => adjustY(textBase)(textHRatio)(origins);
-  const [adjDayH] = adjustTextY([dateHeight]);
+  const [adjDayH] = adjustY(textBase, textHRatio, [dateHeight]);
 
   /** @description 캔들 위치 조정 */
-  const adjustCandleY = (origins: number[]): number[] => adjustY(lowest)(/** hRatio */ 1)(origins);
   /** @constant adjX adjusted X, 오른쪽부터 최신순 */
   const adjX = -idx * bodyWidth - 60;
-  const [adjOpen, adjClose, adjLow, adjHigh] = adjustCandleY([open, close, low, high]);
+  const [adjOpen, adjClose, adjLow, adjHigh] = adjustY(lowest, /** hRatio */ 1, [open, close, low, high]);
   const bodyHeight = adjClose - adjOpen;
   ctx.save();
 

--- a/packages/wiii/frontend/utils/chart/sma.ts
+++ b/packages/wiii/frontend/utils/chart/sma.ts
@@ -1,14 +1,26 @@
 /**
  * @description 보조지표 helpers
  */
-
-import { SetSMAOptions } from '@/type/chart';
+import { adjustedData, SetSMAOptions } from '@/type/chart';
 
 /**
- *
+ * getAvg
+ * @description
+ * duration에 따른 이동평균 산출
+ * @param data 조정된 가격 배열
+ * @param start 구간 시작
+ * @param duration 구간 길이
+ * @returns 구간 이동평균
+ */
+const getAvg = (data: adjustedData, start: number, duration: number) =>
+  data.slice(start, start + duration).reduce((acc, { adjClose }) => acc + adjClose, 0) / duration;
+
+/**
+ * setSMA
  * @description
  * 종가 기준 단순 이동평균선 그리기
- *
+ * @param ctx CanvasContext
+ * @param SMAOptions data 및 이동평균선 옵션
  */
 export const setSMA = (ctx: CanvasRenderingContext2D, { data, hRatio, duration, color }: SetSMAOptions) => {
   /** 가장 오래된 기간은 제외 */
@@ -19,20 +31,16 @@ export const setSMA = (ctx: CanvasRenderingContext2D, { data, hRatio, duration, 
   ctx.strokeStyle = color;
   ctx.scale(1, hRatio);
 
-  const getAvg = (start: number) =>
-    data.slice(start, start + duration).reduce((acc, { adjClose }) => acc + adjClose, 0) / duration;
-
-  let prevM = getAvg(length);
-
+  let prevAvg = getAvg(data, length, duration);
   /** @description 가장 오래된 캔들부터 계산 */
   for (let i = length; i--; ) {
     const { candleCenter: prevX } = data[i + 1];
     const { candleCenter: curX } = data[i];
-    const m = getAvg(i);
+    const curAvg = getAvg(data, i, duration);
     ctx.beginPath();
-    ctx.moveTo(prevX, prevM);
-    ctx.lineTo(curX, m);
-    prevM = m;
+    ctx.moveTo(prevX, prevAvg);
+    ctx.lineTo(curX, curAvg);
+    prevAvg = curAvg;
     ctx.stroke();
   }
   ctx.restore();

--- a/packages/wiii/frontend/utils/chart/sma.ts
+++ b/packages/wiii/frontend/utils/chart/sma.ts
@@ -1,0 +1,39 @@
+/**
+ * @description 보조지표 helpers
+ */
+
+import { SetSMAOptions } from '@/type/chart';
+
+/**
+ *
+ * @description
+ * 종가 기준 단순 이동평균선 그리기
+ *
+ */
+export const setSMA = (ctx: CanvasRenderingContext2D, { data, hRatio, duration, color }: SetSMAOptions) => {
+  /** 가장 오래된 기간은 제외 */
+  const length = data.length - duration;
+  if (duration > length) return;
+
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.scale(1, hRatio);
+
+  const getAvg = (start: number) =>
+    data.slice(start, start + duration).reduce((acc, { adjClose }) => acc + adjClose, 0) / duration;
+
+  let prevM = getAvg(length);
+
+  /** @description 가장 오래된 캔들부터 계산 */
+  for (let i = length; i--; ) {
+    const { candleCenter: prevX } = data[i + 1];
+    const { candleCenter: curX } = data[i];
+    const m = getAvg(i);
+    ctx.beginPath();
+    ctx.moveTo(prevX, prevM);
+    ctx.lineTo(curX, m);
+    prevM = m;
+    ctx.stroke();
+  }
+  ctx.restore();
+};

--- a/packages/wiii/frontend/views/Markets/Stocks.vue
+++ b/packages/wiii/frontend/views/Markets/Stocks.vue
@@ -1,5 +1,8 @@
 <template>
-  <Chart :typeName="`stock`" />
+  <main class="area">
+    <Chart :typeName="`stock`" />
+    <Chart :typeName="`stock`" :timespan="`week`" :from="`2017-01-24`" />
+  </main>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57997672/119812234-e5323c00-bf22-11eb-8e05-0bb373bf6198.png)

## Feat: CandleChart 기능 추가

- Candle 비율 현재 canvas에서 padding 제외하고 꽉차도록 조정
- 일자구분선, 가격구분선, 이동평균선 추가
- 가독성 보다는 렌더링 속도 위해 반복문은 전통적인 for 위주로 사용
- 멀티 차트 (일봉 + 주봉) 한번에 렌더링할 경우 캔들 수 적은 차트부터 먼저 렌더링되는 것 확인, 전체 1초 가량 소요

## TODO

- 일자 및 가격 텍스트 위치 조정
- Refactoring