### PR TITLE
Add common news api

### DIFF
--- a/packages/common/backend/model/ArticleModel.ts
+++ b/packages/common/backend/model/ArticleModel.ts
@@ -7,7 +7,7 @@ export const enum ArticleType {
   opinions = 'opinions',
 }
 
-export interface IArticle extends mongoose.Document {
+export interface ArticleDoc extends mongoose.Document {
   image_url: string;
   title: string;
   text: string;
@@ -34,6 +34,6 @@ const ArticleSchema = new Schema({
   },
 });
 
-const Article = model<IArticle>('Articles', ArticleSchema);
+const Article = model<ArticleDoc>('Articles', ArticleSchema);
 
 export default Article;

--- a/packages/common/backend/model/ArticleModel.ts
+++ b/packages/common/backend/model/ArticleModel.ts
@@ -2,6 +2,21 @@ import mongoose from 'common/backend/mongoose';
 
 const { Schema, model } = mongoose;
 
+export const enum ArticleType {
+  news = 'news',
+  opinions = 'opinions',
+}
+
+export interface IArticle extends mongoose.Document {
+  image_url: string;
+  title: string;
+  text: string;
+  source: string;
+  date: Date;
+  tickers: string[];
+  type: ArticleType;
+}
+
 /**
  * @description 뉴스, 의견 데이터를 위한 모델 스키마
  */
@@ -12,9 +27,13 @@ const ArticleSchema = new Schema({
   source: { type: String, required: true },
   date: { type: Date, required: true },
   tickers: [String],
-  type: { type: String, enum: ['news', 'opinions'], default: 'news' },
+  type: {
+    type: String,
+    enum: [ArticleType.news, ArticleType.opinions],
+    default: ArticleType.news,
+  },
 });
 
-const Article = model('Articles', ArticleSchema);
+const Article = model<IArticle>('Articles', ArticleSchema);
 
 export default Article;

--- a/packages/common/backend/model/ArticleModel.ts
+++ b/packages/common/backend/model/ArticleModel.ts
@@ -1,0 +1,20 @@
+import mongoose from 'common/backend/mongoose';
+
+const { Schema, model } = mongoose;
+
+/**
+ * @description 뉴스, 의견 데이터를 위한 모델 스키마
+ */
+const ArticleSchema = new Schema({
+  image_url: { type: String, required: true },
+  title: { type: String, required: true },
+  text: { type: String, required: true },
+  source: { type: String, required: true },
+  date: { type: Date, required: true },
+  tickers: [String],
+  type: { type: String, enum: ['news', 'opinions'], default: 'news' },
+});
+
+const Article = model('Articles', ArticleSchema);
+
+export default Article;

--- a/packages/common/backend/mongoose/index.ts
+++ b/packages/common/backend/mongoose/index.ts
@@ -1,0 +1,3 @@
+import * as mongoose from 'mongoose';
+
+export default mongoose;

--- a/packages/common/backend/service/ArticleService.ts
+++ b/packages/common/backend/service/ArticleService.ts
@@ -1,0 +1,24 @@
+import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import Article, { ArticleType, ArticleDoc } from '../model/ArticleModel';
+
+interface QueryProps {
+  offset?: number;
+  limit?: number;
+}
+
+@Service()
+export default class ArticleService {
+  public async getNews({ offset = 0, limit = 10 }: QueryProps): Promise<ArticleDoc[]> {
+    return Article.find({ type: ArticleType.news })
+      .skip(offset)
+      .limit(limit)
+      .lean<ArticleDoc[]>();
+  }
+
+  public async getOpinions({ offset = 0, limit = 10 }: QueryProps): Promise<ArticleDoc[]> {
+    return Article.find({ type: ArticleType.opinions })
+      .skip(offset)
+      .limit(limit)
+      .lean<ArticleDoc[]>();
+  }
+}

--- a/packages/common/backend/service/ArticleService.ts
+++ b/packages/common/backend/service/ArticleService.ts
@@ -1,3 +1,4 @@
+import { isValidObjectId, ObjectId } from 'mongoose';
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import Article, { ArticleType, ArticleDoc } from '../model/ArticleModel';
 
@@ -20,5 +21,11 @@ export default class ArticleService {
       .skip(offset)
       .limit(limit)
       .lean<ArticleDoc[]>();
+  }
+
+  public async getArticleById(id: ObjectId | string): Promise<ArticleDoc> {
+    if (!isValidObjectId(id)) throw new Error('invalid id');
+
+    return Article.findById(id).lean<ArticleDoc>();
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
     "@vue/cli-plugin-babel": "^4.5.13",
     "@vue/cli-plugin-typescript": "^4.5.13",
     "cross-env": "^7.0.3",
+    "mongoose": "^5.12.12",
     "typescript": "^4.2.4",
     "vue": "^2.6.12",
     "zum-portal-core": "1.1.1"

--- a/packages/dogyeong/src/backend/Server.ts
+++ b/packages/dogyeong/src/backend/Server.ts
@@ -1,7 +1,9 @@
 import 'reflect-metadata';
 import { appContainer } from 'common/backend/AppContainer';
-import * as mongoose from 'mongoose';
+import mongoose from 'common/backend/mongoose';
 import { mongoConfig } from './config';
+
+mongoose.set('debug', true);
 
 mongoose
   .connect(mongoConfig.uri, mongoConfig.options)

--- a/packages/dogyeong/src/backend/model/UserModel.ts
+++ b/packages/dogyeong/src/backend/model/UserModel.ts
@@ -1,4 +1,6 @@
-import { Schema, model } from 'mongoose';
+import mongoose from 'common/backend/mongoose';
+
+const { Schema, model } = mongoose;
 
 const UserSchema = new Schema({
   email: String,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,21 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.5"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3156,6 +3171,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
+
 bfj@^6.1.1:
   version "6.1.2"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
@@ -3787,6 +3810,11 @@ chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -4848,6 +4876,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -9263,6 +9296,14 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -9310,7 +9351,7 @@ mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdir
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -9340,7 +9381,7 @@ mongodb@3.6.6:
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongodb@^3.6.7:
+mongodb@3.6.8, mongodb@^3.6.7:
   version "3.6.8"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/mongodb/-/mongodb-3.6.8.tgz#3e2632af81915b3ff99b7681121ca0895e8ed407"
   integrity sha512-sDjJvI73WjON1vapcbyBD3Ao9/VN3TKYY8/QX9EPbs22KaCSrQ5rXo5ZZd44tWJ3wl3FlnrFZ+KyUtNH6+1ZPQ==
@@ -9367,6 +9408,24 @@ mongoose@^5.12.10:
     bson "^1.1.4"
     kareem "2.3.2"
     mongodb "3.6.6"
+    mongoose-legacy-pluralize "1.0.2"
+    mpath "0.8.3"
+    mquery "3.2.5"
+    ms "2.1.2"
+    regexp-clone "1.0.0"
+    safe-buffer "5.2.1"
+    sift "13.5.2"
+    sliced "1.0.1"
+
+mongoose@^5.12.12:
+  version "5.12.12"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/mongoose/-/mongoose-5.12.12.tgz#7da29c7d7924ad1fb07b5c5fc0acde2f4aaff4f9"
+  integrity sha512-n+ZmGApaL5x/r92w6S4pb+c075i+YKzg1F9YWkznSzQMtvetj/2dSjj2cqsITpd6z60k3K7ZaosIl6hzHwUA9g==
+  dependencies:
+    "@types/mongodb" "^3.5.27"
+    bson "^1.1.4"
+    kareem "2.3.2"
+    mongodb "3.6.8"
     mongoose-legacy-pluralize "1.0.2"
     mpath "0.8.3"
     mquery "3.2.5"
@@ -9537,6 +9596,11 @@ node-addon-api@^1.7.1:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-cache@^4.1.1:
   version "4.2.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
@@ -9557,7 +9621,7 @@ node-cleanup@^2.1.2:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -9817,7 +9881,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.1.2:
   version "4.1.2"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -11746,7 +11810,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -12626,6 +12690,18 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
+tar@^6.1.0:
+  version "6.1.0"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
@@ -13458,6 +13534,11 @@ vue-awesome-swiper@4.1.1:
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/vue-awesome-swiper/-/vue-awesome-swiper-4.1.1.tgz#8f7ab221ad003021d756b86aa618f429924900fe"
   integrity sha512-50um10t6N+lJaORkpwSi1wWuMmBI1sgFc9Znsi5oUykw2cO5DzLaBHcO2JNX21R+Ue4TGoIJDhhxjBHtkFrTEQ==
 
+vue-cookies@^1.7.4:
+  version "1.7.4"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/vue-cookies/-/vue-cookies-1.7.4.tgz#d241d0a0431da0795837651d10b4d73e7c8d3e8d"
+  integrity sha512-mOS5Btr8V9zvAtkmQ7/TfqJIropOx7etDAgBywPCmHjvfJl2gFbH2XgoMghleLoyyMTi5eaJss0mPN7arMoslA==
+
 vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.6.0:
   version "7.6.0"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/vue-eslint-parser/-/vue-eslint-parser-7.6.0.tgz#01ea1a2932f581ff244336565d712801f8f72561"
@@ -13547,6 +13628,11 @@ vue@2.6.12, vue@^2.6.12, vue@~2.6.12:
   version "2.6.12"
   resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+vuex-module-decorators@^1.0.1:
+  version "1.0.1"
+  resolved "http://ci-portal.zuminternet.com/nexus/repository/zum-portal-npm/vuex-module-decorators/-/vuex-module-decorators-1.0.1.tgz#d34dafb5428a3636f1c26d3d014c15fc9659ccd0"
+  integrity sha512-FLWZsXV5XAtl/bcKUyQFpnSBtpc3wK/7zSdy9oKbyp71mZd4ut5y2zSd219wWW9OG7WUOlVwac4rXFFDVnq7ug==
 
 vuex@~3.6.0:
   version "3.6.2"


### PR DESCRIPTION
## 작업내용

- `mongoose`를 common에서 사용하도록 변경
  - 다른 패키지에서 따로 mongoose 인스턴스를 사용하면 에러가 나서 common에서 export해주고, 다른 패키지에서는 이를 사용하도록 했습니다
- ArticleModel, ArticleService 추가
  - 뉴스와 의견이 거의 비슷한 구조라서 articles라는 하나의 컬렉션에서 type으로 나눠지도록 했습니다
  - 스키마는 추후 계속 수정할 예정
- 뉴스, 의견의 더미 데이터
  -  https://www.notion.so/zuminternet/df8de75a3aaa4caea62b335f96d15bca