### PR TITLE
Fix: EventSource-Component 데이터 연동, MarketService 캐싱 문제 해결

### DIFF
--- a/packages/wiii/backend/controller/MarketController.ts
+++ b/packages/wiii/backend/controller/MarketController.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from 'express'
-import { Controller, GetMapping } from 'zum-portal-core/backend/decorator/Controller'
+import { Request, Response } from 'express';
+import { Controller, GetMapping } from 'zum-portal-core/backend/decorator/Controller';
 
-import SSE from './SSE'
-import { GetHistoricalOptions } from '../../domain/apiOptions'
-import { marketHome, marketName, marketSubpaths } from '../../domain/apiUrls'
-import { MarketService } from '../service/MarketService'
-import { times } from '../../domain/date'
+import SSE from './SSE';
+import { GetHistoricalOptions } from '../../domain/apiOptions';
+import { marketHome, marketName, marketSubpaths } from '../../domain/apiUrls';
+import { MarketService } from '../service/MarketService';
+import { times } from '../../domain/date';
 
 /**
  * parseQueryToOptions

--- a/packages/wiii/backend/controller/MarketController.ts
+++ b/packages/wiii/backend/controller/MarketController.ts
@@ -6,6 +6,7 @@ import { GetHistoricalOptions } from '../../domain/apiOptions';
 import { marketHome, marketName, marketSubpaths } from '../../domain/apiUrls';
 import { MarketService } from '../service/MarketService';
 import { times } from '../../domain/date';
+import { Inject } from 'zum-portal-core/backend/decorator/Alias';
 
 /**
  * parseQueryToOptions
@@ -59,8 +60,7 @@ const isOptionsValidate = (options: GetHistoricalOptions): boolean => {
  */
 @Controller({ path: marketHome })
 export class MarketController {
-  constructor() // @Inject(MarketService) private marketService: MarketService
-  {
+  constructor(@Inject(MarketService) private marketService: MarketService) {
     /** @todo Yml 또는 Injection 있는 경우 */
   }
 
@@ -86,13 +86,13 @@ export class MarketController {
       /** SSE Response Instance 생성 */
       new SSE(res, options);
 
-      const data = await MarketService.getHistorical(options);
+      const data = await this.marketService.getHistorical(options);
       this.writeData(data, res);
 
       /** 15초 간격 SSE, @todo 조정해도 계속 3초 간격 요청..? => debounce 처리해야.. */
       const intervalTime = times.sse * 3000;
       const eventSourceInterval = setInterval(async () => {
-        const data = await MarketService.getHistorical(options);
+        const data = await this.marketService.getHistorical(options);
         this.writeData(data, res);
       }, /** 15s */ intervalTime);
 

--- a/packages/wiii/backend/service/MarketService.ts
+++ b/packages/wiii/backend/service/MarketService.ts
@@ -1,10 +1,12 @@
-import { Service } from 'zum-portal-core/backend/decorator/Alias'
-import { Caching } from 'zum-portal-core/backend/decorator/Caching'
+import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import { Caching } from 'zum-portal-core/backend/decorator/Caching';
 
-import { GetHistoricalOptions } from '../../domain/apiOptions'
-import { marketName } from '../../domain/apiUrls'
-import { times } from '../../domain/date'
-import { fetchHistoricalData as historicalKoreanData } from '../chart/KRX'
+import { GetHistoricalOptions } from '../../domain/apiOptions';
+import { marketName } from '../../domain/apiUrls';
+import { times } from '../../domain/date';
+import { fetchHistoricalData as historicalKoreanData } from '../chart/KRX';
+
+const IS_PRO_MODE = process.env.NODE_ENV === `production`;
 
 const fetchers = {
   [marketName.stocks]: historicalKoreanData,
@@ -28,9 +30,7 @@ export class MarketService {
    * @Yml('marketApi') private MarketApi: any,
    * @Inject(ZumProvisionAdapter) private adapter: ZumProvisionAdapter,
    */
-  {
-    /** @todo  */
-  }
+  {}
 
   /**
    * getStockHistorical
@@ -38,20 +38,25 @@ export class MarketService {
    * @description
    * 실무에서는 webSocket 등 실시간 데이터 업데이트 해야 하지만
    * 파일럿 프로젝트에서는 무료 api를 사용하므로 사용량 제한 위해 캐싱 사용,
+   * @todo node-caching 안되는 문제..? client 요청할 때마다 매번 API 요청 보내게 됨..
    */
   @Caching({
-    refreshCron: `30 * * * * *`,
-    /** 1분 단위 캐싱 */
-    ttl: times.caching,
+    /** 개발모드에서는 1시간에 한 번만 실행 */
+    refreshCron: IS_PRO_MODE ? `30 * * * * *` : `1 * * *`,
+    /** 캐싱 기간 초 단위 */
+    ttl: IS_PRO_MODE ? times.caching : times.caching * 60,
     runOnStart: false,
     unless: (result) => !result,
   })
-  public static async getHistorical(options: GetHistoricalOptions) {
+  public async getHistorical(options: GetHistoricalOptions) {
     try {
       const { type } = options;
+
+      /** response: data, status, statusText, headers, config */
       const { data, status, statusText } = await fetchers[type](options);
       console.log({ status, statusText });
       resultValidator(data, status, statusText);
+
       return data;
     } catch (e) {
       return console.error(e);

--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -127,7 +127,6 @@ export default Vue.extend({
     getChart() {
       console.info(`[Chart] Start to create a Chart`);
       console.assert(this.ctx);
-      console.assert(this.histData.data.length);
       console.table(this.histData.data);
       /**  @todo */
       // drawBasicCandleChart({

--- a/packages/wiii/frontend/services/chart/eventSource.ts
+++ b/packages/wiii/frontend/services/chart/eventSource.ts
@@ -62,8 +62,7 @@ export default class EsService {
     if (this.location !== location.href) this.onClose();
 
     try {
-      const result = Object.freeze(JSON.parse(data));
-      this.observer['data'] = result;
+      this.observer['data'] = Object.freeze(JSON.parse(data));
     } catch (e) {
       console.error(e);
     }

--- a/packages/wiii/frontend/services/chart/eventSource.ts
+++ b/packages/wiii/frontend/services/chart/eventSource.ts
@@ -10,12 +10,13 @@ import { GetHistoricalOptions } from '../../../domain/apiOptions';
  */
 export default class EsService {
   url: string;
+  private observer: object;
   private es: EventSource;
   private location: string;
-  private _data: object;
 
-  constructor(query: GetHistoricalOptions) {
+  constructor(query: GetHistoricalOptions, dataCarrier: ProxyConstructor) {
     this.url = this.setUrl(query);
+    this.observer = dataCarrier;
     this.location = location.href;
 
     /**
@@ -25,10 +26,6 @@ export default class EsService {
     this.es = new EventSource(this.url);
 
     this.addEventListers();
-  }
-
-  public get data() {
-    return Object.freeze(this._data);
   }
 
   /**
@@ -55,8 +52,8 @@ export default class EsService {
     this.es.addEventListener(`message`, this.onMessage.bind(this));
   }
 
+  /** 서버 연결 시 로직.. */
   private onOpen() {
-    /** @todo 서버 연결 시 로직.. */
     console.info(`[SSR:Client] Connection Opened`);
   }
 
@@ -65,8 +62,8 @@ export default class EsService {
     if (this.location !== location.href) this.onClose();
 
     try {
-      const result = JSON.parse(data);
-      this._data = result;
+      const result = Object.freeze(JSON.parse(data));
+      this.observer['data'] = result;
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
## Fix: EventSource onMessage 데이터 -> Chart 컴포넌트 연동

- Proxy 사용하여 notify
  - EventSource 내부 private 메서드에서 set -> component data 변경

## Fix: MarketService 캐싱 문제 해결 …

- `getHistorical` method가 static으로 선언되어 Caching 안됐던 부분 해결
  - Controller에서 Injection
  - 개발 모드에선 캐싱 시간을 1시간으로 늘림