### PR TITLE
Implement news tab

### DIFF
--- a/packages/common/frontend/components/News/NewsTextBox.vue
+++ b/packages/common/frontend/components/News/NewsTextBox.vue
@@ -16,3 +16,9 @@ export default Vue.extend({
   name: 'NewsTextBox',
 });
 </script>
+
+<style scoped>
+.news-text-container {
+  flex: 1;
+}
+</style>

--- a/packages/dogyeong/src/frontend/components/Header/HeaderNav.vue
+++ b/packages/dogyeong/src/frontend/components/Header/HeaderNav.vue
@@ -1,6 +1,8 @@
 <template>
   <nav>
-    <slot></slot>
+    <ul class="header-nav-list">
+      <slot></slot>
+    </ul>
   </nav>
 </template>
 
@@ -18,8 +20,12 @@ nav {
   padding: 0 12px;
   background-color: var(--header-nav-bg-color);
 
-  li {
-    cursor: pointer;
+  .header-nav-list {
+    display: flex;
+
+    li {
+      cursor: pointer;
+    }
   }
 }
 </style>

--- a/packages/dogyeong/src/frontend/components/Header/HeaderNavItem.vue
+++ b/packages/dogyeong/src/frontend/components/Header/HeaderNavItem.vue
@@ -1,0 +1,31 @@
+<template>
+  <li :class="{ active: active }" @click.prevent="$emit('clickItem')">
+    <slot></slot>
+  </li>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'HeaderNavItem',
+
+  props: {
+    active: {
+      type: Boolean,
+      default: () => false,
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+li {
+  margin-right: 16px;
+  color: var(--sub-text-color);
+
+  &.active {
+    color: var(--text-color);
+  }
+}
+</style>

--- a/packages/dogyeong/src/frontend/components/Header/index.ts
+++ b/packages/dogyeong/src/frontend/components/Header/index.ts
@@ -1,5 +1,6 @@
 import Header from '@/components/Header/Header.vue';
 import HeaderTitle from '@/components/Header/HeaderTitle.vue';
 import HeaderNav from '@/components/Header/HeaderNav.vue';
+import HeaderNavItem from '@/components/Header/HeaderNavItem.vue';
 
-export { Header, HeaderTitle, HeaderNav };
+export { Header, HeaderTitle, HeaderNav, HeaderNavItem };

--- a/packages/dogyeong/src/frontend/components/Layout/Layout.vue
+++ b/packages/dogyeong/src/frontend/components/Layout/Layout.vue
@@ -15,7 +15,9 @@ export default Vue.extend({});
   height: 100%;
 
   main {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    flex: 1;
   }
 }
 </style>

--- a/packages/dogyeong/src/frontend/components/Market/MarketIndex.vue
+++ b/packages/dogyeong/src/frontend/components/Market/MarketIndex.vue
@@ -27,5 +27,3 @@ export default Vue.extend({
   },
 });
 </script>
-
-<style></style>

--- a/packages/dogyeong/src/frontend/components/NewsTemplate/NewsTemplate.vue
+++ b/packages/dogyeong/src/frontend/components/NewsTemplate/NewsTemplate.vue
@@ -1,0 +1,130 @@
+<template>
+  <div>
+    <section class="news-section">
+      <NewsHeadline v-if="headline" :to="`${prefix}${headline._id}`">
+        <NewsImage :src="headline.image_url" />
+        <NewsTextBox>
+          <NewsTextBoxTitle>{{ headline.title }}</NewsTextBoxTitle>
+          <NewsTextBoxDesc :author="headline.source" :publish-date="headline.date" />
+        </NewsTextBox>
+      </NewsHeadline>
+      <NewsList v-if="news">
+        <NewsListItem v-for="newsItem in news" :key="newsItem._id" :to="`${prefix}${newsItem._id}`">
+          <NewsImage :src="newsItem.image_url" />
+          <NewsTextBox>
+            <NewsTextBoxTitle>{{ newsItem.title }}</NewsTextBoxTitle>
+            <NewsTextBoxDesc :author="newsItem.source" :publish-date="newsItem.date" />
+          </NewsTextBox>
+        </NewsListItem>
+      </NewsList>
+    </section>
+    <section class="opinions-section">
+      <h2 class="section-title">분석 및 의견</h2>
+      <NewsList v-if="opinions">
+        <NewsListItem v-for="opinion in opinions" :key="opinion._id" :to="`${prefix}${opinion._id}`">
+          <NewsImage :src="opinion.image_url" rounded />
+          <NewsTextBox>
+            <NewsTextBoxTitle>{{ opinion.title }}</NewsTextBoxTitle>
+            <NewsTextBoxDesc :author="opinion.source" :publish-date="opinion.date" />
+          </NewsTextBox>
+        </NewsListItem>
+      </NewsList>
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import {
+  NewsHeadline,
+  NewsTextBoxTitle,
+  NewsTextBoxDesc,
+  NewsTextBox,
+  NewsImage,
+  NewsList,
+  NewsListItem,
+} from 'common/frontend/components/News';
+
+export default Vue.extend({
+  name: 'NewsTemplate',
+
+  components: {
+    NewsHeadline,
+    NewsTextBoxTitle,
+    NewsTextBoxDesc,
+    NewsTextBox,
+    NewsImage,
+    NewsList,
+    NewsListItem,
+  },
+
+  props: {
+    headline: {
+      type: Object,
+      required: true,
+    },
+    news: {
+      type: Array,
+      required: true,
+    },
+    opinions: {
+      type: Array,
+      required: true,
+    },
+    urlPrefix: {
+      type: String,
+      required: true,
+    },
+  },
+
+  computed: {
+    prefix() {
+      const prefix = this.urlPrefix.startsWith('/') ? '' : '/';
+      const suffix = this.urlPrefix.endsWith('/') ? '' : '/';
+      return `${prefix}${this.urlPrefix}${suffix}`;
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+.news-section,
+.opinions-section {
+  .news-headline {
+    a .news-text-container {
+      padding: 16px 12px;
+    }
+  }
+
+  .news-headline,
+  .news-list-item {
+    a,
+    a.news-link {
+      background-color: var(--bg-color);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    h4 {
+      color: var(--text-color);
+      word-break: keep-all;
+      overflow: hidden;
+      font-size: 18px;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+
+    .news-author,
+    .news-date {
+      color: var(--sub-text-color);
+      font-size: 13px;
+    }
+  }
+
+  .section-title {
+    font-size: 24px;
+    padding: 36px 12px;
+  }
+}
+</style>

--- a/packages/dogyeong/src/frontend/components/Swiper/index.ts
+++ b/packages/dogyeong/src/frontend/components/Swiper/index.ts
@@ -1,0 +1,4 @@
+import Swiper from '@/components/Swiper/Swiper.vue';
+import SwiperSlide from '@/components/Swiper/SwiperSlide.vue';
+
+export { Swiper, SwiperSlide };

--- a/packages/dogyeong/src/frontend/config/index.ts
+++ b/packages/dogyeong/src/frontend/config/index.ts
@@ -9,8 +9,10 @@ export const apiEndpoints = {
   getStocks: '/api/stocks',
   getSummary: '/api/summary',
   getChart: '/api/chart',
-  getNews: '/api/news',
-  getOpinions: '/api/opinions',
+  getNewNews: '/api/news/new',
+  getNewOpinions: '/api/opinions/new',
+  getPopularNews: '/api/news/popular',
+  getPopularOpinions: '/api/opinions/popular',
 };
 
 export const googleAuthInitConfig = {

--- a/packages/dogyeong/src/frontend/config/index.ts
+++ b/packages/dogyeong/src/frontend/config/index.ts
@@ -9,6 +9,8 @@ export const apiEndpoints = {
   getStocks: '/api/stocks',
   getSummary: '/api/summary',
   getChart: '/api/chart',
+  getNews: '/api/news',
+  getOpinions: '/api/opinions',
 };
 
 export const googleAuthInitConfig = {

--- a/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
+++ b/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
@@ -1,6 +1,6 @@
-export default ({ init, fetchData }) => ({
+export default ({ fetchData }) => ({
   created() {
-    init.bind(this)();
+    this.fetchData();
   },
 
   methods: {

--- a/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
+++ b/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
@@ -1,6 +1,6 @@
-export default ({ fetchData }) => ({
+export default ({ init, fetchData }) => ({
   created() {
-    this.fetchData();
+    init.bind(this)();
   },
 
   methods: {

--- a/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
+++ b/packages/dogyeong/src/frontend/mixin/swiperMixin.ts
@@ -20,7 +20,6 @@ export default ({ fetchData }) => ({
 
     slideTo(index) {
       this.$refs.swiper.slideTo(index);
-      this.fetchData();
     },
   },
 });

--- a/packages/dogyeong/src/frontend/services/articleService.ts
+++ b/packages/dogyeong/src/frontend/services/articleService.ts
@@ -8,15 +8,29 @@ interface Query {
   limit?: number;
 }
 
-export const getNews = async ({ offset = 0, limit = 10 }: Query = {}) => {
-  const { data } = await Axios.get(apiEndpoints.getNews, {
+export const getNewNews = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getNewNews, {
     params: { offset, limit },
   });
   return data;
 };
 
-export const getOpinions = async ({ offset = 0, limit = 10 }: Query = {}) => {
-  const { data } = await Axios.get(apiEndpoints.getOpinions, {
+export const getNewOpinions = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getNewOpinions, {
+    params: { offset, limit },
+  });
+  return data;
+};
+
+export const getPopularNews = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getPopularNews, {
+    params: { offset, limit },
+  });
+  return data;
+};
+
+export const getPopularOpinions = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getPopularOpinions, {
     params: { offset, limit },
   });
   return data;

--- a/packages/dogyeong/src/frontend/services/articleService.ts
+++ b/packages/dogyeong/src/frontend/services/articleService.ts
@@ -1,0 +1,14 @@
+import { AxiosStatic } from 'axios';
+import { apiEndpoints } from '@/config';
+
+declare const Axios: AxiosStatic;
+
+export const getNews = async () => {
+  const { data } = await Axios.get(apiEndpoints.getNews);
+  return data;
+};
+
+export const getOpinions = async () => {
+  const { data } = await Axios.get(apiEndpoints.getOpinions);
+  return data;
+};

--- a/packages/dogyeong/src/frontend/services/articleService.ts
+++ b/packages/dogyeong/src/frontend/services/articleService.ts
@@ -3,12 +3,21 @@ import { apiEndpoints } from '@/config';
 
 declare const Axios: AxiosStatic;
 
-export const getNews = async () => {
-  const { data } = await Axios.get(apiEndpoints.getNews);
+interface Query {
+  offset?: number;
+  limit?: number;
+}
+
+export const getNews = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getNews, {
+    params: { offset, limit },
+  });
   return data;
 };
 
-export const getOpinions = async () => {
-  const { data } = await Axios.get(apiEndpoints.getOpinions);
+export const getOpinions = async ({ offset = 0, limit = 10 }: Query = {}) => {
+  const { data } = await Axios.get(apiEndpoints.getOpinions, {
+    params: { offset, limit },
+  });
   return data;
 };

--- a/packages/dogyeong/src/frontend/store/articleStore.ts
+++ b/packages/dogyeong/src/frontend/store/articleStore.ts
@@ -93,6 +93,16 @@ export default () => {
     },
 
     actions: {
+      async getInitialNewArticles({ state, dispatch }) {
+        const { news, opinions } = state.new;
+        if (!news.data.length) dispatch('getNewNews');
+        if (!opinions.data.length) dispatch('getNewOpinions');
+      },
+      async getInitialPopularArticles({ state, dispatch }) {
+        const { news, opinions } = state.popular;
+        if (!news.data.length) dispatch('getPopularNews');
+        if (!opinions.data.length) dispatch('getPopularOpinions');
+      },
       async getNewNews({ state, commit }, reset = false) {
         try {
           const { news } = state.new;

--- a/packages/dogyeong/src/frontend/store/articleStore.ts
+++ b/packages/dogyeong/src/frontend/store/articleStore.ts
@@ -93,65 +93,73 @@ export default () => {
     },
 
     actions: {
-      async getNewNews({ state, commit }) {
+      async getNewNews({ state, commit }, reset = false) {
         try {
           const { news } = state.new;
+          const offset = reset ? 0 : news.data.length;
 
           if (news.isLoading) return;
 
           commit('setNewNewsLoading');
 
-          const newNews = await articleService.getNews();
+          const newNews = await articleService.getNews({ offset });
+          const nextState = reset ? newNews : [...news.data, ...newNews];
 
-          commit('setNewNews', [...news.data, ...newNews]);
+          commit('setNewNews', nextState);
         } catch (e) {
           commit('setNewNewsError');
           console.error(e);
         }
       },
-      async getNewOpinions({ state, commit }) {
+      async getNewOpinions({ state, commit }, reset = false) {
         try {
           const { opinions } = state.new;
+          const offset = reset ? 0 : opinions.data.length;
 
           if (opinions.isLoading) return;
 
           commit('setNewOpinionsLoading');
 
-          const newOpinions = await articleService.getOpinions();
+          const newOpinions = await articleService.getOpinions({ offset });
+          const nextState = reset ? newOpinions : [...opinions.data, ...newOpinions];
 
-          commit('setNewOpinions', [...opinions.data, ...newOpinions]);
+          commit('setNewOpinions', nextState);
         } catch (e) {
           commit('setNewOpinionsError');
           console.error(e);
         }
       },
-      async getPopularNews({ state, commit }) {
+      async getPopularNews({ state, commit }, reset = false) {
         try {
           const { news } = state.popular;
+          const offset = reset ? 0 : news.data.length;
 
           if (news.isLoading) return;
 
           commit('setPopularNewsLoading');
 
-          const popularNews = await articleService.getNews();
+          const popularNews = await articleService.getNews({ offset });
+          const nextState = reset ? popularNews : [...news.data, ...popularNews];
 
-          commit('setPopularNews', [...news.data, ...popularNews]);
+          commit('setPopularNews', nextState);
         } catch (e) {
           commit('setPopularNewsError');
           console.error(e);
         }
       },
-      async getPopularOpinions({ state, commit }) {
+      async getPopularOpinions({ state, commit }, reset = false) {
         try {
           const { opinions } = state.popular;
+          const offset = reset ? 0 : opinions.data.length;
 
           if (opinions.isLoading) return;
 
           commit('setPopularOpinionsLoading');
 
-          const popularOpinions = await articleService.getOpinions();
+          const popularOpinions = await articleService.getOpinions({ offset });
+          const nextState = reset ? popularOpinions : [...opinions.data, ...popularOpinions];
 
-          commit('setPopularOpinions', [...opinions.data, ...popularOpinions]);
+          commit('setPopularOpinions', nextState);
         } catch (e) {
           commit('setPopularOpinionsError');
           console.error(e);

--- a/packages/dogyeong/src/frontend/store/articleStore.ts
+++ b/packages/dogyeong/src/frontend/store/articleStore.ts
@@ -102,7 +102,7 @@ export default () => {
 
           commit('setNewNewsLoading');
 
-          const newNews = await articleService.getNews({ offset });
+          const newNews = await articleService.getNewNews({ offset });
           const nextState = reset ? newNews : [...news.data, ...newNews];
 
           commit('setNewNews', nextState);
@@ -120,7 +120,7 @@ export default () => {
 
           commit('setNewOpinionsLoading');
 
-          const newOpinions = await articleService.getOpinions({ offset });
+          const newOpinions = await articleService.getNewOpinions({ offset });
           const nextState = reset ? newOpinions : [...opinions.data, ...newOpinions];
 
           commit('setNewOpinions', nextState);
@@ -138,7 +138,7 @@ export default () => {
 
           commit('setPopularNewsLoading');
 
-          const popularNews = await articleService.getNews({ offset });
+          const popularNews = await articleService.getPopularNews({ offset });
           const nextState = reset ? popularNews : [...news.data, ...popularNews];
 
           commit('setPopularNews', nextState);
@@ -156,7 +156,7 @@ export default () => {
 
           commit('setPopularOpinionsLoading');
 
-          const popularOpinions = await articleService.getOpinions({ offset });
+          const popularOpinions = await articleService.getPopularOpinions({ offset });
           const nextState = reset ? popularOpinions : [...opinions.data, ...popularOpinions];
 
           commit('setPopularOpinions', nextState);

--- a/packages/dogyeong/src/frontend/store/articleStore.ts
+++ b/packages/dogyeong/src/frontend/store/articleStore.ts
@@ -1,0 +1,162 @@
+import * as articleService from '@/services/articleService';
+
+export default () => {
+  return {
+    state: {
+      new: {
+        news: {
+          data: [],
+          isLoading: false,
+          isError: false,
+        },
+        opinions: {
+          data: [],
+          isLoading: false,
+          isError: false,
+        },
+      },
+      popular: {
+        news: {
+          data: [],
+          isLoading: false,
+          isError: false,
+        },
+        opinions: {
+          data: [],
+          isLoading: false,
+          isError: false,
+        },
+      },
+    },
+
+    mutations: {
+      setNewNews(state, news = []) {
+        state.new.news = {
+          data: news,
+          isLoading: false,
+          isError: false,
+        };
+      },
+      setNewNewsLoading({ new: { news } }) {
+        news.isLoading = true;
+        news.isError = false;
+      },
+      setNewNewsError({ new: { news } }) {
+        news.isLoading = false;
+        news.isError = true;
+      },
+      setNewOpinions(state, opinions = []) {
+        state.new.opinions = {
+          data: opinions,
+          isLoading: false,
+          isError: false,
+        };
+      },
+      setNewOpinionsLoading({ new: { opinions } }) {
+        opinions.isLoading = true;
+        opinions.isError = false;
+      },
+      setNewOpinionsError({ new: { opinions } }) {
+        opinions.isLoading = false;
+        opinions.isError = true;
+      },
+      setPopularNews(state, news = []) {
+        state.popular.news = {
+          data: news,
+          isLoading: false,
+          isError: false,
+        };
+      },
+      setPopularNewsLoading({ popular: { news } }) {
+        news.isLoading = true;
+        news.isError = false;
+      },
+      setPopularNewsError({ popular: { news } }) {
+        news.isLoading = false;
+        news.isError = true;
+      },
+      setPopularOpinions(state, opinions = []) {
+        state.popular.opinions = {
+          data: opinions,
+          isLoading: false,
+          isError: false,
+        };
+      },
+      setPopularOpinionsLoading({ popular: { opinions } }) {
+        opinions.isLoading = true;
+        opinions.isError = false;
+      },
+      setPopularOpinionsError({ popular: { opinions } }) {
+        opinions.isLoading = false;
+        opinions.isError = true;
+      },
+    },
+
+    actions: {
+      async getNewNews({ state, commit }) {
+        try {
+          const { news } = state.new;
+
+          if (news.isLoading) return;
+
+          commit('setNewNewsLoading');
+
+          const newNews = await articleService.getNews();
+
+          commit('setNewNews', [...news.data, ...newNews]);
+        } catch (e) {
+          commit('setNewNewsError');
+          console.error(e);
+        }
+      },
+      async getNewOpinions({ state, commit }) {
+        try {
+          const { opinions } = state.new;
+
+          if (opinions.isLoading) return;
+
+          commit('setNewOpinionsLoading');
+
+          const newOpinions = await articleService.getOpinions();
+
+          commit('setNewOpinions', [...opinions.data, ...newOpinions]);
+        } catch (e) {
+          commit('setNewOpinionsError');
+          console.error(e);
+        }
+      },
+      async getPopularNews({ state, commit }) {
+        try {
+          const { news } = state.popular;
+
+          if (news.isLoading) return;
+
+          commit('setPopularNewsLoading');
+
+          const popularNews = await articleService.getNews();
+
+          commit('setPopularNews', [...news.data, ...popularNews]);
+        } catch (e) {
+          commit('setPopularNewsError');
+          console.error(e);
+        }
+      },
+      async getPopularOpinions({ state, commit }) {
+        try {
+          const { opinions } = state.popular;
+
+          if (opinions.isLoading) return;
+
+          commit('setPopularOpinionsLoading');
+
+          const popularOpinions = await articleService.getOpinions();
+
+          commit('setPopularOpinions', [...opinions.data, ...popularOpinions]);
+        } catch (e) {
+          commit('setPopularOpinionsError');
+          console.error(e);
+        }
+      },
+    },
+  };
+};

--- a/packages/dogyeong/src/frontend/store/index.ts
+++ b/packages/dogyeong/src/frontend/store/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import createUserStore from '@/store/userStore';
 import financeStore from '@/store/financeStore';
+import articleStore from '@/store/articleStore';
 
 Vue.use(Vuex);
 
@@ -10,6 +11,7 @@ export default () => {
     modules: {
       user: createUserStore(),
       finance: financeStore(),
+      article: articleStore(),
     },
 
     state: {

--- a/packages/dogyeong/src/frontend/views/Market.vue
+++ b/packages/dogyeong/src/frontend/views/Market.vue
@@ -61,6 +61,9 @@ export default Vue.extend({
 
   mixins: [
     swiperMixin({
+      init() {
+        this.fetchData();
+      },
       fetchData() {
         if (this.currentNavId === 'index') this.getIndices();
         if (this.currentNavId === 'stock') this.getStocks();

--- a/packages/dogyeong/src/frontend/views/Market.vue
+++ b/packages/dogyeong/src/frontend/views/Market.vue
@@ -61,9 +61,6 @@ export default Vue.extend({
 
   mixins: [
     swiperMixin({
-      init() {
-        this.fetchData();
-      },
       fetchData() {
         if (this.currentNavId === 'index') this.getIndices();
         if (this.currentNavId === 'stock') this.getStocks();

--- a/packages/dogyeong/src/frontend/views/Market.vue
+++ b/packages/dogyeong/src/frontend/views/Market.vue
@@ -3,16 +3,14 @@
     <Header>
       <HeaderTitle>시장</HeaderTitle>
       <HeaderNav>
-        <ul class="header-nav-list">
-          <li
-            v-for="route in navRoutes"
-            :key="route.id"
-            :class="{ active: route.id === currentNavId }"
-            @click.prevent="onClickHeaderNav(route.id)"
-          >
-            {{ route.title }}
-          </li>
-        </ul>
+        <HeaderNavItem
+          v-for="route in navRoutes"
+          :key="route.id"
+          :active="route.id === currentNavId"
+          @clickItem="onClickHeaderNav(route.id)"
+        >
+          {{ route.title }}
+        </HeaderNavItem>
       </HeaderNav>
     </Header>
     <main>
@@ -35,14 +33,13 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { Header, HeaderTitle, HeaderNav } from '@/components/Header';
+import { Header, HeaderTitle, HeaderNav, HeaderNavItem } from '@/components/Header';
 import Layout from '@/components/Layout/Layout.vue';
 import BottomNav from '@/components/BottomNav/BottomNav.vue';
 import MarketIndex from '@/components/Market/MarketIndex.vue';
 import MarketCoin from '@/components/Market/MarketCoin.vue';
 import MarketStock from '@/components/Market/MarketStock.vue';
-import Swiper from '@/components/Swiper/Swiper.vue';
-import SwiperSlide from '@/components/Swiper/SwiperSlide.vue';
+import { Swiper, SwiperSlide } from '@/components/Swiper';
 import swiperMixin from '@/mixin/swiperMixin';
 
 export default Vue.extend({
@@ -59,6 +56,7 @@ export default Vue.extend({
     HeaderNav,
     Swiper,
     SwiperSlide,
+    HeaderNavItem,
   },
 
   mixins: [
@@ -96,17 +94,4 @@ export default Vue.extend({
 });
 </script>
 
-<style lang="scss" scoped>
-.header-nav-list {
-  display: flex;
-
-  li {
-    margin-right: 16px;
-    color: var(--sub-text-color);
-
-    &.active {
-      color: var(--text-color);
-    }
-  }
-}
-</style>
+<style lang="scss" scoped></style>

--- a/packages/dogyeong/src/frontend/views/News.vue
+++ b/packages/dogyeong/src/frontend/views/News.vue
@@ -95,13 +95,9 @@ export default Vue.extend({
 
   mixins: [
     swiperMixin({
-      init() {
-        this.getNewNews(true);
-        this.getNewOpinions(true);
-      },
       fetchData() {
-        if (this.currentNavId === 'new') this.getNewNews();
-        if (this.currentNavId === 'popular') this.getNewOpinions();
+        if (this.currentNavId === 'new') this.getInitialNewArticles();
+        if (this.currentNavId === 'popular') this.getInitialPopularArticles();
       },
     }),
   ],
@@ -130,7 +126,14 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions(['getNewNews', 'getNewOpinions', 'getPopularNews', 'getPopularOpinions']),
+    ...mapActions([
+      'getNewNews',
+      'getNewOpinions',
+      'getPopularNews',
+      'getPopularOpinions',
+      'getInitialNewArticles',
+      'getInitialPopularArticles',
+    ]),
 
     onClickHeaderNav(id) {
       this.handleHeaderNavClick(id);

--- a/packages/dogyeong/src/frontend/views/News.vue
+++ b/packages/dogyeong/src/frontend/views/News.vue
@@ -36,8 +36,8 @@
           </section>
           <section class="opinions-section">
             <h2 class="section-title">분석 및 의견</h2>
-            <NewsList v-if="opinions">
-              <NewsListItem v-for="opinion in opinions" :key="opinion._id" :to="`/news/${opinion._id}`">
+            <NewsList v-if="newOpinions">
+              <NewsListItem v-for="opinion in newOpinions" :key="opinion._id" :to="`/news/${opinion._id}`">
                 <NewsImage :src="opinion.image_url" rounded />
                 <NewsTextBox>
                   <NewsTextBoxTitle>{{ opinion.title }}</NewsTextBoxTitle>
@@ -70,7 +70,7 @@ import {
 } from 'common/frontend/components/News';
 import { Swiper, SwiperSlide } from '@/components/Swiper';
 import swiperMixin from '@/mixin/swiperMixin';
-import * as articleService from '@/services/articleService';
+import { mapActions, mapState } from 'vuex';
 
 export default Vue.extend({
   name: 'News',
@@ -95,10 +95,13 @@ export default Vue.extend({
 
   mixins: [
     swiperMixin({
+      init() {
+        this.getNewNews(true);
+        this.getNewOpinions(true);
+      },
       fetchData() {
-        /** @TODO 수정 */
-        if (this.currentNavId === 'new') this.getNews();
-        if (this.currentNavId === 'popular') this.getOpinions();
+        if (this.currentNavId === 'new') this.getNewNews();
+        if (this.currentNavId === 'popular') this.getNewOpinions();
       },
     }),
   ],
@@ -117,28 +120,24 @@ export default Vue.extend({
 
   computed: {
     headline() {
-      return this.news[0];
+      return this.newNews[0];
     },
     normalNews() {
-      return this.news.slice(1);
+      return this.newNews.slice(1);
     },
+    ...mapState({ newNews: ({ article }) => article.new.news.data }),
+    ...mapState({ newOpinions: ({ article }) => article.new.opinions.data }),
   },
 
   methods: {
+    ...mapActions(['getNewNews', 'getNewOpinions', 'getPopularNews', 'getPopularOpinions']),
+
     onClickHeaderNav(id) {
       this.handleHeaderNavClick(id);
     },
 
     onEndSlide(swiper) {
       this.handleEndSlide(swiper);
-    },
-
-    getNews() {
-      articleService.getNews().then((news) => (this.news = news));
-    },
-
-    getOpinions() {
-      articleService.getOpinions().then((opinions) => (this.opinions = opinions));
     },
   },
 });

--- a/packages/dogyeong/src/frontend/views/News.vue
+++ b/packages/dogyeong/src/frontend/views/News.vue
@@ -16,38 +16,17 @@
     <main>
       <Swiper ref="swiper" @endSlide="onEndSlide">
         <SwiperSlide>
-          <section class="news-section">
-            <NewsHeadline v-if="headline" :to="`/news/${headline._id}`">
-              <NewsImage :src="headline.image_url" />
-              <NewsTextBox>
-                <NewsTextBoxTitle>{{ headline.title }}</NewsTextBoxTitle>
-                <NewsTextBoxDesc :author="headline.source" :publish-date="headline.date" />
-              </NewsTextBox>
-            </NewsHeadline>
-            <NewsList v-if="normalNews">
-              <NewsListItem v-for="newsItem in normalNews" :key="newsItem._id" :to="`/news/${newsItem._id}`">
-                <NewsImage :src="newsItem.image_url" />
-                <NewsTextBox>
-                  <NewsTextBoxTitle>{{ newsItem.title }}</NewsTextBoxTitle>
-                  <NewsTextBoxDesc :author="newsItem.source" :publish-date="newsItem.date" />
-                </NewsTextBox>
-              </NewsListItem>
-            </NewsList>
-          </section>
-          <section class="opinions-section">
-            <h2 class="section-title">분석 및 의견</h2>
-            <NewsList v-if="newOpinions">
-              <NewsListItem v-for="opinion in newOpinions" :key="opinion._id" :to="`/news/${opinion._id}`">
-                <NewsImage :src="opinion.image_url" rounded />
-                <NewsTextBox>
-                  <NewsTextBoxTitle>{{ opinion.title }}</NewsTextBoxTitle>
-                  <NewsTextBoxDesc :author="opinion.source" :publish-date="opinion.date" />
-                </NewsTextBox>
-              </NewsListItem>
-            </NewsList>
-          </section>
+          <NewsTemplate v-if="headline" :headline="headline" :news="normalNews" :opinions="newOpinions" url-prefix="/news/new" />
         </SwiperSlide>
-        <SwiperSlide> </SwiperSlide>
+        <SwiperSlide>
+          <NewsTemplate
+            v-if="headline"
+            :headline="headline"
+            :news="normalNews"
+            :opinions="newOpinions"
+            url-prefix="/news/popular"
+          />
+        </SwiperSlide>
       </Swiper>
     </main>
     <BottomNav></BottomNav>
@@ -59,16 +38,8 @@ import Vue from 'vue';
 import BottomNav from '@/components/BottomNav/BottomNav.vue';
 import { Header, HeaderTitle, HeaderNav, HeaderNavItem } from '@/components/Header';
 import Layout from '@/components/Layout/Layout.vue';
-import {
-  NewsHeadline,
-  NewsTextBoxTitle,
-  NewsTextBoxDesc,
-  NewsTextBox,
-  NewsImage,
-  NewsList,
-  NewsListItem,
-} from 'common/frontend/components/News';
 import { Swiper, SwiperSlide } from '@/components/Swiper';
+import NewsTemplate from '@/components/NewsTemplate/NewsTemplate.vue';
 import swiperMixin from '@/mixin/swiperMixin';
 import { mapActions, mapState } from 'vuex';
 
@@ -81,16 +52,10 @@ export default Vue.extend({
     HeaderTitle,
     HeaderNavItem,
     Layout,
-    NewsHeadline,
-    NewsTextBoxTitle,
-    NewsTextBoxDesc,
-    NewsTextBox,
-    NewsImage,
-    NewsList,
-    NewsListItem,
     HeaderNav,
     Swiper,
     SwiperSlide,
+    NewsTemplate,
   },
 
   mixins: [

--- a/packages/dogyeong/src/frontend/views/News.vue
+++ b/packages/dogyeong/src/frontend/views/News.vue
@@ -1,21 +1,187 @@
 <template>
-  <div>
+  <Layout>
+    <Header>
+      <HeaderTitle>뉴스</HeaderTitle>
+      <HeaderNav>
+        <HeaderNavItem
+          v-for="route in navRoutes"
+          :key="route.id"
+          :active="route.id === currentNavId"
+          @clickItem="onClickHeaderNav(route.id)"
+        >
+          {{ route.title }}
+        </HeaderNavItem>
+      </HeaderNav>
+    </Header>
+    <main>
+      <Swiper ref="swiper" @endSlide="onEndSlide">
+        <SwiperSlide>
+          <section class="news-section">
+            <NewsHeadline v-if="headline" :to="`/news/${headline._id}`">
+              <NewsImage :src="headline.image_url" />
+              <NewsTextBox>
+                <NewsTextBoxTitle>{{ headline.title }}</NewsTextBoxTitle>
+                <NewsTextBoxDesc :author="headline.source" :publish-date="headline.date" />
+              </NewsTextBox>
+            </NewsHeadline>
+            <NewsList v-if="normalNews">
+              <NewsListItem v-for="newsItem in normalNews" :key="newsItem._id" :to="`/news/${newsItem._id}`">
+                <NewsImage :src="newsItem.image_url" />
+                <NewsTextBox>
+                  <NewsTextBoxTitle>{{ newsItem.title }}</NewsTextBoxTitle>
+                  <NewsTextBoxDesc :author="newsItem.source" :publish-date="newsItem.date" />
+                </NewsTextBox>
+              </NewsListItem>
+            </NewsList>
+          </section>
+          <section class="opinions-section">
+            <h2 class="section-title">분석 및 의견</h2>
+            <NewsList v-if="opinions">
+              <NewsListItem v-for="opinion in opinions" :key="opinion._id" :to="`/news/${opinion._id}`">
+                <NewsImage :src="opinion.image_url" rounded />
+                <NewsTextBox>
+                  <NewsTextBoxTitle>{{ opinion.title }}</NewsTextBoxTitle>
+                  <NewsTextBoxDesc :author="opinion.source" :publish-date="opinion.date" />
+                </NewsTextBox>
+              </NewsListItem>
+            </NewsList>
+          </section>
+        </SwiperSlide>
+        <SwiperSlide> </SwiperSlide>
+      </Swiper>
+    </main>
     <BottomNav></BottomNav>
-  </div>
+  </Layout>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import BottomNav from '@/components/BottomNav/BottomNav.vue';
+import { Header, HeaderTitle, HeaderNav, HeaderNavItem } from '@/components/Header';
+import Layout from '@/components/Layout/Layout.vue';
+import {
+  NewsHeadline,
+  NewsTextBoxTitle,
+  NewsTextBoxDesc,
+  NewsTextBox,
+  NewsImage,
+  NewsList,
+  NewsListItem,
+} from 'common/frontend/components/News';
+import { Swiper, SwiperSlide } from '@/components/Swiper';
+import swiperMixin from '@/mixin/swiperMixin';
+import * as articleService from '@/services/articleService';
 
 export default Vue.extend({
   name: 'News',
-  components: { BottomNav },
+
+  components: {
+    BottomNav,
+    Header,
+    HeaderTitle,
+    HeaderNavItem,
+    Layout,
+    NewsHeadline,
+    NewsTextBoxTitle,
+    NewsTextBoxDesc,
+    NewsTextBox,
+    NewsImage,
+    NewsList,
+    NewsListItem,
+    HeaderNav,
+    Swiper,
+    SwiperSlide,
+  },
+
+  mixins: [
+    swiperMixin({
+      fetchData() {
+        /** @TODO 수정 */
+        if (this.currentNavId === 'new') this.getNews();
+        if (this.currentNavId === 'popular') this.getOpinions();
+      },
+    }),
+  ],
+
+  data() {
+    return {
+      news: [],
+      opinions: [],
+      navRoutes: [
+        { id: 'new', title: '최신', index: 0 },
+        { id: 'popular', title: '가장 인기 있는 뉴스', index: 1 },
+      ],
+      currentNavId: 'new',
+    };
+  },
+
+  computed: {
+    headline() {
+      return this.news[0];
+    },
+    normalNews() {
+      return this.news.slice(1);
+    },
+  },
+
+  methods: {
+    onClickHeaderNav(id) {
+      this.handleHeaderNavClick(id);
+    },
+
+    onEndSlide(swiper) {
+      this.handleEndSlide(swiper);
+    },
+
+    getNews() {
+      articleService.getNews().then((news) => (this.news = news));
+    },
+
+    getOpinions() {
+      articleService.getOpinions().then((opinions) => (this.opinions = opinions));
+    },
+  },
 });
 </script>
 
-<style lang="scss" scoped>
-div {
-  background-color: blue;
+<style lang="scss">
+.news-section,
+.opinions-section {
+  .news-headline {
+    a .news-text-container {
+      padding: 16px 12px;
+    }
+  }
+
+  .news-headline,
+  .news-list-item {
+    a,
+    a.news-link {
+      background-color: var(--bg-color);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    h4 {
+      color: var(--text-color);
+      word-break: keep-all;
+      overflow: hidden;
+      font-size: 18px;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+
+    .news-author,
+    .news-date {
+      color: var(--sub-text-color);
+      font-size: 13px;
+    }
+  }
+
+  .section-title {
+    font-size: 24px;
+    padding: 36px 12px;
+  }
 }
 </style>


### PR DESCRIPTION
## 작업내용

- 공용 뉴스리스트 컴포넌트 스타일 수정
- 뉴스, 의견 API 연동
  - `articleStore` 추가
  - `articleService` 추가
- 리팩토링
  - 헤더 네비게이션 컴포넌트로 분리
  - 반복되는 뉴스리스트 부분을 별도의 `NewsTemplate` 컴포넌트로 분리

## Screenshots

![Animation](https://user-images.githubusercontent.com/40662323/120297040-aaa21800-c303-11eb-86c6-a13e3a137abc.gif)
