### PR TITLE
[feature] 종목 상세 페이지 overview, news, analysis 렌더링 로직 추가(백엔드 연동)

### DIFF
--- a/packages/common/backend/service/ItemDetailService.ts
+++ b/packages/common/backend/service/ItemDetailService.ts
@@ -16,25 +16,21 @@ export default class ItemDetailService {
    * @returns
    */
   public async getItemDetail({ symbols }) {
-    try {
-      const { accessKey } = marketStackConfig;
-      const itemDetailSubInfo1 = await (
-        await axios.get(`http://api.marketstack.com/v1/eod?access_key=${accessKey}&symbols=${symbols}&limit=1`)
-      ).data;
+    const { accessKey } = marketStackConfig;
+    const itemDetailSubInfo1 = await (
+      await axios.get(`http://api.marketstack.com/v1/eod?access_key=${accessKey}&symbols=${symbols}&limit=1`)
+    ).data;
 
-      const itemDetailSubInfo2 = await (
-        await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${symbols}&limit=1`)
-      ).data;
+    const itemDetailSubInfo2 = await (
+      await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${symbols}&limit=1`)
+    ).data;
 
-      const itemDetailInfo = { ...itemDetailSubInfo1.data[0], ...itemDetailSubInfo2.data[0] };
+    const itemDetailInfo = { ...itemDetailSubInfo1.data[0], ...itemDetailSubInfo2.data[0] };
 
-      if (itemDetailInfo) {
-        return itemDetailInfo;
-      }
-
-      throw new Error('Getting item detail info was failed in ItemDetailService');
-    } catch (error) {
-      console.log(error);
+    if (itemDetailInfo) {
+      return itemDetailInfo;
     }
+
+    throw new Error('Getting item detail info was failed in ItemDetailService');
   }
 }

--- a/packages/common/backend/service/ItemDetailService.ts
+++ b/packages/common/backend/service/ItemDetailService.ts
@@ -17,13 +17,13 @@ export default class ItemDetailService {
    */
   public async getItemDetail({ symbols }) {
     const { accessKey } = marketStackConfig;
-    const itemDetailSubInfo1 = await (
-      await axios.get(`http://api.marketstack.com/v1/eod?access_key=${accessKey}&symbols=${symbols}&limit=1`)
-    ).data;
+    const { data: itemDetailSubInfo1 } = await axios.get(
+      `http://api.marketstack.com/v1/eod?access_key=${accessKey}&symbols=${symbols}&limit=1`,
+    );
 
-    const itemDetailSubInfo2 = await (
-      await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${symbols}&limit=1`)
-    ).data;
+    const { data: itemDetailSubInfo2 } = await axios.get(
+      `http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${symbols}&limit=1`,
+    );
 
     const itemDetailInfo = { ...itemDetailSubInfo1.data[0], ...itemDetailSubInfo2.data[0] };
 

--- a/packages/common/backend/service/SearchService.ts
+++ b/packages/common/backend/service/SearchService.ts
@@ -18,7 +18,7 @@ export default class SearchService {
    */
   public async getSearchedItems({ keyword }: getSearchedItemsInfo) {
     const { accessKey } = marketStackConfig;
-    let items = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${keyword}`)).data;
+    let { data: items } = await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${keyword}`);
 
     if (items) {
       // items = items.map((item) => {

--- a/packages/common/backend/service/SearchService.ts
+++ b/packages/common/backend/service/SearchService.ts
@@ -17,21 +17,17 @@ export default class SearchService {
    * @returns items
    */
   public async getSearchedItems({ keyword }: getSearchedItemsInfo) {
-    try {
-      const { accessKey } = marketStackConfig;
-      let items = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${keyword}`)).data;
+    const { accessKey } = marketStackConfig;
+    let items = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}&search=${keyword}`)).data;
 
-      if (items) {
-        // items = items.map((item) => {
-        //   return {};
-        // });
+    if (items) {
+      // items = items.map((item) => {
+      //   return {};
+      // });
 
-        return items;
-      }
-
-      throw new Error('getting searched items was failed in SearchService');
-    } catch (error) {
-      console.log(error);
+      return items;
     }
+
+    throw new Error('getting searched items was failed in SearchService');
   }
 }

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -45,10 +45,10 @@ const getSearchedItems = async ({ keyword }: getSearchedItemsInfo) => {
 
 const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
   try {
-    const result = await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}`);
+    const itemDetail = (await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}`)).data;
 
-    if (result) {
-      return result;
+    if (itemDetail) {
+      return itemDetail;
     }
 
     throw new Error('Getting item detail was failed in front api');
@@ -64,7 +64,7 @@ const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
  */
 const getNews = async ({ offset, limit }: getNewsInfo) => {
   try {
-    const news = await Axios.get(`${devURL}/api/articles/news?offset=${offset}&limit=${limit}`);
+    const news = (await Axios.get(`${devURL}/api/articles/news?offset=${offset}&limit=${limit}`)).data;
 
     if (news) {
       return news;

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -74,9 +74,15 @@ const getNews = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
   }
 };
 
+/**
+ * @description item detail page에 렌더링할 analyses를 가져오는 front-side API 호출 함수
+ * @param param0
+ * @returns
+ */
+
 const getAnalyses = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
   try {
-    const analyses = await Axios.get(`${devURL}/api/articles/analyses?offset=${offset}&limit=${limit}`);
+    const analyses = await (await Axios.get(`${devURL}/api/articles/analyses?offset=${offset}&limit=${limit}`)).data;
 
     if (analyses) {
       return analyses;

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -12,7 +12,7 @@ export interface getItemDetailInfo {
   symbols: string;
 }
 
-export interface getNewsInfo {
+export interface getNewsAndAnalysesInfo {
   offset: Number;
   limit: Number;
 }
@@ -22,7 +22,6 @@ export interface getNewsInfo {
  * @param param0
  * @returns
  */
-
 const getSearchedItems = async ({ keyword }: getSearchedItemsInfo) => {
   try {
     const result = await Axios.get(`${devURL}/api/search/items?keyword=${keyword}`);
@@ -42,7 +41,6 @@ const getSearchedItems = async ({ keyword }: getSearchedItemsInfo) => {
  * @param param0
  * @returns
  */
-
 const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
   try {
     const itemDetail = (await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}`)).data;
@@ -62,7 +60,7 @@ const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
  * @param param0
  * @returns
  */
-const getNews = async ({ offset, limit }: getNewsInfo) => {
+const getNews = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
   try {
     const news = (await Axios.get(`${devURL}/api/articles/news?offset=${offset}&limit=${limit}`)).data;
 
@@ -76,4 +74,18 @@ const getNews = async ({ offset, limit }: getNewsInfo) => {
   }
 };
 
-export { getSearchedItems, getItemDetail, getNews };
+const getAnalyses = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
+  try {
+    const analyses = await Axios.get(`${devURL}/api/articles/analyses?offset=${offset}&limit=${limit}`);
+
+    if (analyses) {
+      return analyses;
+    }
+
+    throw new Error('Getting analyses was failed in front api');
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export { getSearchedItems, getItemDetail, getNews, getAnalyses };

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -12,6 +12,11 @@ export interface getItemDetailInfo {
   symbols: string;
 }
 
+export interface getNewsInfo {
+  offset: Number;
+  limit: Number;
+}
+
 /**
  * @description search page에 렌더링할 searched items를 가져오는 front-side API 호출 함수
  * @param param0
@@ -32,6 +37,12 @@ const getSearchedItems = async ({ keyword }: getSearchedItemsInfo) => {
   }
 };
 
+/**
+ * @description item detail page에 렌더링할 item detail를 가져오는 front-side API 호출 함수
+ * @param param0
+ * @returns
+ */
+
 const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
   try {
     const result = await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}`);
@@ -46,4 +57,23 @@ const getItemDetail = async ({ symbols }: getItemDetailInfo) => {
   }
 };
 
-export { getSearchedItems, getItemDetail };
+/**
+ * @description item detail page에 렌더링할 news들을 가져오는 front-side API 호출 함수 현재 item detail용 service가 없어서 대체 사용중
+ * @param param0
+ * @returns
+ */
+const getNews = async ({ offset, limit }: getNewsInfo) => {
+  try {
+    const news = await Axios.get(`${devURL}/api/articles/news?offset=${offset}&limit=${limit}`);
+
+    if (news) {
+      return news;
+    }
+
+    throw new Error('Getting news was failed in front api');
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export { getSearchedItems, getItemDetail, getNews };

--- a/packages/common/frontend/components/ItemDetail/ItemDetailOverallContent.vue
+++ b/packages/common/frontend/components/ItemDetail/ItemDetailOverallContent.vue
@@ -33,16 +33,16 @@
 </template>
 
 <script>
-import ItemDetailOverallInfoBox from '../components/ItemDetailOverallInfoBox.vue';
-import SubContentBox from '../components/ItemDetail/SubContentBox.vue';
-import NewsList from '../components/News/NewsList.vue';
-import NewsListItem from '../components/News/NewsListItem.vue';
-import NewsImage from '../components/News/NewsImage.vue';
-import NewsTextBox from '../components/News/NewsTextBox.vue';
-import NewsTextBoxTitle from '../components/News/NewsTextBoxTitle.vue';
-import NewsTextBoxDesc from '../components/News/NewsTextBoxDesc.vue';
+import ItemDetailOverallInfoBox from './ItemDetailOverallInfoBox.vue';
+import SubContentBox from './SubContentBox.vue';
+import NewsList from '../News/NewsList.vue';
+import NewsListItem from '../News/NewsListItem.vue';
+import NewsImage from '../News/NewsImage.vue';
+import NewsTextBox from '../News/NewsTextBox.vue';
+import NewsTextBoxTitle from '../News/NewsTextBoxTitle.vue';
+import NewsTextBoxDesc from '../News/NewsTextBoxDesc.vue';
 
-import { text } from '../constants';
+import { text } from '../../constants';
 export default {
   name: 'ItemDetailOverallContent',
   components: {

--- a/packages/common/frontend/components/ItemDetail/ItemDetailOverallInfoBox.vue
+++ b/packages/common/frontend/components/ItemDetail/ItemDetailOverallInfoBox.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script>
-import ItemDetailOverallInfoRow from '../components/ItemDetailOverallInfoRow.vue';
-import { text } from '../constants';
+import ItemDetailOverallInfoRow from './ItemDetailOverallInfoRow.vue';
+import { text } from '../../constants';
 
 export default {
   name: 'ItemDetailOverallInfoBox',

--- a/packages/common/frontend/components/ItemDetail/ItemDetailOverallInfoRow.vue
+++ b/packages/common/frontend/components/ItemDetail/ItemDetailOverallInfoRow.vue
@@ -8,9 +8,9 @@
 </template>
 
 <script>
-import CustomText from '../components/CustomText.vue';
-import EmptySpace from '../components/karl/EmptySpace.vue';
-import { text } from '../constants';
+import CustomText from '../CustomText.vue';
+import EmptySpace from '../karl/EmptySpace.vue';
+import { text } from '../../constants';
 
 export default {
   name: 'ItemDetailOverallInfoRow',

--- a/packages/common/frontend/components/ItemDetail/ItemDetailPriceBox.vue
+++ b/packages/common/frontend/components/ItemDetail/ItemDetailPriceBox.vue
@@ -19,8 +19,8 @@
 </template>
 
 <script>
-import CustomText from '../components/CustomText.vue';
-import EmptySpace from '../components/karl/EmptySpace.vue';
+import CustomText from '../CustomText.vue';
+import EmptySpace from '../karl/EmptySpace.vue';
 
 export default {
   name: 'ItemDetailPriceBox',

--- a/packages/common/frontend/components/ItemDetail/SubContentBox.vue
+++ b/packages/common/frontend/components/ItemDetail/SubContentBox.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="sub-content-box">
+    <div class="sub-content-box-button" @click="$emit('handle-sub-content-box-button')">
+      <custom-text>{{ text }}</custom-text>
+      <empty-space></empty-space>
+      <div class="right-arrow-img"></div>
+    </div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+import CustomText from '../CustomText.vue';
+import EmptySpace from '../karl/EmptySpace.vue';
+
+export default {
+  components: { CustomText, EmptySpace },
+  name: 'SubContentBox',
+
+  props: {
+    text: {
+      type: String,
+      require: true,
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.sub-content-box {
+  width: 100%;
+}
+
+.sub-content-box-button {
+  display: flex;
+  height: 20px;
+  background-color: gray;
+  align-items: center;
+}
+
+.right-arrow-img {
+  width: 15px;
+  height: 15px;
+  background-color: red;
+}
+</style>

--- a/packages/common/frontend/components/ItemDetailOverallContent.vue
+++ b/packages/common/frontend/components/ItemDetailOverallContent.vue
@@ -1,24 +1,30 @@
 <template>
   <div class="item-detail-overall-content" :style="style">
     <!-- 차트 컴포넌트 자리  -->
+    <!-- overview 컴포넌트 자리 -->
     <item-detail-overall-info-box :itemDetail="itemDetail"></item-detail-overall-info-box>
-    <news-list>
-      <news-list-item v-for="element in news" :key="element.id" :to="''">
-        <news-image :src="element.image_url" />
-        <news-text-box>
-          <news-text-box-title>{{ element.title }}</news-text-box-title>
-          <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
-        </news-text-box>
-      </news-list-item>
-    </news-list>
+
     <!-- 댓글 컴포넌트 자리 -->
     <!-- 뉴스 컴포넌트 자리 -->
+    <sub-content-box :text="newsText">
+      <news-list>
+        <news-list-item v-for="element in news" :key="element.id" :to="''">
+          <news-image :src="element.image_url" />
+          <news-text-box>
+            <news-text-box-title>{{ element.title }}</news-text-box-title>
+            <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
+          </news-text-box>
+        </news-list-item>
+      </news-list>
+    </sub-content-box>
+
     <!-- 분석 컴포넌트 자리 -->
   </div>
 </template>
 
 <script>
 import ItemDetailOverallInfoBox from '../components/ItemDetailOverallInfoBox.vue';
+import SubContentBox from '../components/ItemDetail/SubContentBox.vue';
 import NewsList from '../components/News/NewsList.vue';
 import NewsListItem from '../components/News/NewsListItem.vue';
 import NewsImage from '../components/News/NewsImage.vue';
@@ -26,6 +32,7 @@ import NewsTextBox from '../components/News/NewsTextBox.vue';
 import NewsTextBoxTitle from '../components/News/NewsTextBoxTitle.vue';
 import NewsTextBoxDesc from '../components/News/NewsTextBoxDesc.vue';
 
+import { text } from '../constants';
 export default {
   name: 'ItemDetailOverallContent',
   components: {
@@ -36,6 +43,7 @@ export default {
     NewsTextBox,
     NewsTextBoxTitle,
     NewsTextBoxDesc,
+    SubContentBox,
   },
   props: {
     itemDetail: {
@@ -60,6 +68,16 @@ export default {
         height: `calc(100vh - ${this.excludingHeight}px)`,
       };
     },
+  },
+
+  data() {
+    const { NEWS, ANALYSIS, OPINION } = text;
+
+    return {
+      newsText: NEWS,
+      analysisText: ANALYSIS,
+      opnionText: OPINION,
+    };
   },
 };
 </script>

--- a/packages/common/frontend/components/ItemDetailOverallContent.vue
+++ b/packages/common/frontend/components/ItemDetailOverallContent.vue
@@ -2,7 +2,15 @@
   <div class="item-detail-overall-content" :style="style">
     <!-- 차트 컴포넌트 자리  -->
     <item-detail-overall-info-box :itemDetail="itemDetail"></item-detail-overall-info-box>
-    <news-list></news-list>
+    <news-list>
+      <news-list-item v-for="element in news" :key="element.id" :to="''">
+        <news-image :src="element.image_url" />
+        <news-text-box>
+          <news-text-box-title>{{ element.title }}</news-text-box-title>
+          <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
+        </news-text-box>
+      </news-list-item>
+    </news-list>
     <!-- 댓글 컴포넌트 자리 -->
     <!-- 뉴스 컴포넌트 자리 -->
     <!-- 분석 컴포넌트 자리 -->
@@ -12,16 +20,31 @@
 <script>
 import ItemDetailOverallInfoBox from '../components/ItemDetailOverallInfoBox.vue';
 import NewsList from '../components/News/NewsList.vue';
+import NewsListItem from '../components/News/NewsListItem.vue';
+import NewsImage from '../components/News/NewsImage.vue';
+import NewsTextBox from '../components/News/NewsTextBox.vue';
+import NewsTextBoxTitle from '../components/News/NewsTextBoxTitle.vue';
+import NewsTextBoxDesc from '../components/News/NewsTextBoxDesc.vue';
 
 export default {
   name: 'ItemDetailOverallContent',
   components: {
     ItemDetailOverallInfoBox,
     NewsList,
+    NewsListItem,
+    NewsImage,
+    NewsTextBox,
+    NewsTextBoxTitle,
+    NewsTextBoxDesc,
   },
   props: {
     itemDetail: {
       type: Object,
+      required: true,
+    },
+
+    news: {
+      type: Array,
       required: true,
     },
 
@@ -47,5 +70,11 @@ export default {
   flex-direction: column;
   flex-wrap: nowrap;
   overflow-y: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.item-detail-overall-content::-webkit-scrollbar {
+  display: none;
 }
 </style>

--- a/packages/common/frontend/components/ItemDetailOverallContent.vue
+++ b/packages/common/frontend/components/ItemDetailOverallContent.vue
@@ -17,8 +17,18 @@
         </news-list-item>
       </news-list>
     </sub-content-box>
-
     <!-- 분석 컴포넌트 자리 -->
+    <sub-content-box :text="analysisText">
+      <news-list>
+        <news-list-item v-for="element in analyses" :key="element.id" :to="''">
+          <news-image :src="element.image_url" />
+          <news-text-box>
+            <news-text-box-title>{{ element.title }}</news-text-box-title>
+            <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
+          </news-text-box>
+        </news-list-item>
+      </news-list>
+    </sub-content-box>
   </div>
 </template>
 
@@ -52,6 +62,11 @@ export default {
     },
 
     news: {
+      type: Array,
+      required: true,
+    },
+
+    analyses: {
       type: Array,
       required: true,
     },

--- a/packages/common/frontend/components/ItemDetailOverallContent.vue
+++ b/packages/common/frontend/components/ItemDetailOverallContent.vue
@@ -2,6 +2,7 @@
   <div class="item-detail-overall-content" :style="style">
     <!-- 차트 컴포넌트 자리  -->
     <item-detail-overall-info-box :itemDetail="itemDetail"></item-detail-overall-info-box>
+    <news-list></news-list>
     <!-- 댓글 컴포넌트 자리 -->
     <!-- 뉴스 컴포넌트 자리 -->
     <!-- 분석 컴포넌트 자리 -->
@@ -10,11 +11,13 @@
 
 <script>
 import ItemDetailOverallInfoBox from '../components/ItemDetailOverallInfoBox.vue';
+import NewsList from '../components/News/NewsList.vue';
 
 export default {
   name: 'ItemDetailOverallContent',
   components: {
     ItemDetailOverallInfoBox,
+    NewsList,
   },
   props: {
     itemDetail: {

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -1,4 +1,4 @@
-import { getItemDetail, getNews } from '../../apis';
+import { getAnalyses, getItemDetail, getNews } from '../../apis';
 
 // 초기 state 값 설정
 const state = () => ({
@@ -54,7 +54,6 @@ const actions = {
     try {
       const news = await getNews({ offset, limit });
 
-      console.log(news);
       if (news) {
         commit('changeNews', news);
 
@@ -62,7 +61,26 @@ const actions = {
       }
 
       throw new Error('Getting news was failed in itemDetail store');
-    } catch (error) {}
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async getAnalyses({ commit }, { offset, limit }) {
+    try {
+      const analyses = await getAnalyses({ offset, limit });
+
+      console.log(analyses);
+      if (analyses) {
+        commit('changeAnalyses', analyses);
+
+        return true;
+      }
+
+      throw new Error('Getting analyses was failed in itemDetail store');
+    } catch (error) {
+      console.log(error);
+    }
   },
 };
 
@@ -90,6 +108,10 @@ const mutations = {
 
   changeNews(state, news) {
     state.news = news;
+  },
+
+  changeAnalyses(state, analyses) {
+    state.analyses = analyses;
   },
 };
 

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -20,8 +20,8 @@ const state = () => ({
     time: '100',
     currency: 'dallor',
   },
-
   news: [],
+  analyses: [],
 });
 
 // getter 설정

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -70,7 +70,6 @@ const actions = {
     try {
       const analyses = await getAnalyses({ offset, limit });
 
-      console.log(analyses);
       if (analyses) {
         commit('changeAnalyses', analyses);
 

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -20,6 +20,8 @@ const state = () => ({
     time: '100',
     currency: 'dallor',
   },
+
+  news: [],
 });
 
 // getter 설정

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -1,4 +1,4 @@
-import { getItemDetail } from '../../apis';
+import { getItemDetail, getNews } from '../../apis';
 
 // 초기 state 값 설정
 const state = () => ({
@@ -36,8 +36,7 @@ const getters = {
 const actions = {
   async getItemDetail({ commit }, { symbols }) {
     try {
-      const result = await getItemDetail({ symbols });
-      const itemDetail = result.data;
+      const itemDetail = await getItemDetail({ symbols });
 
       if (itemDetail) {
         commit('changeItemDetail', itemDetail);
@@ -50,13 +49,28 @@ const actions = {
       console.log(error);
     }
   },
+
+  async getNews({ commit }, { offset, limit }) {
+    try {
+      const news = await getNews({ offset, limit });
+
+      console.log(news);
+      if (news) {
+        commit('changeNews', news);
+
+        return true;
+      }
+
+      throw new Error('Getting news was failed in itemDetail store');
+    } catch (error) {}
+  },
 };
 
 // mutatuons 설정
 const mutations = {
   changeItemDetail(state, itemDetail) {
-    console.log(itemDetail);
     const { name, symbol, country, adj_close, adj_high, adj_low, close, open, volume, stock_exchange, high, low } = itemDetail;
+
     state.itemDetail = {
       ...state.itemDetail,
       name,
@@ -72,8 +86,10 @@ const mutations = {
       high,
       low,
     };
+  },
 
-    console.log(state.itemDetail);
+  changeNews(state, news) {
+    state.news = news;
   },
 };
 

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -87,7 +87,7 @@ const actions = {
 // mutatuons 설정
 const mutations = {
   changeItemDetail(state, itemDetail) {
-    const { name, symbol, country, adj_close, adj_high, adj_low, close, open, volume, stock_exchange, high, low } = itemDetail;
+    const { name, symbol, adj_close, adj_high, adj_low, close, open, volume, stock_exchange, high, low } = itemDetail;
 
     state.itemDetail = {
       ...state.itemDetail,

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -11,9 +11,6 @@
           :excludingHeight="210"
         ></item-detail-overall-content>
       </swiper-slide>
-      <!-- <swiper-slide>
-        <item-detail-overall-content :itemDetail="itemDetail" :excludingHeight="210"></item-detail-overall-content>
-      </swiper-slide> -->
     </custom-swiper>
     <bottom-naviagtor :navigatorButtonNames="bottomNavigatorButtonNames"></bottom-naviagtor>
   </div>
@@ -26,9 +23,9 @@ import { text } from '../constants';
 
 import BottomNaviagtor from '../components/BottomNaviagtor.vue';
 import MultipurposeHeader from '../components/MultipurposeHeader.vue';
-import ItemDetailPriceBox from '../components/ItemDetailPriceBox.vue';
+import ItemDetailPriceBox from '../components/ItemDetail/ItemDetailPriceBox.vue';
 import CustomSwiper from '../components/CustomSwiper.vue';
-import ItemDetailOverallContent from '../components/ItemDetailOverallContent.vue';
+import ItemDetailOverallContent from '../components/ItemDetail/ItemDetailOverallContent.vue';
 
 export default {
   name: 'ItemDetail',

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -4,11 +4,11 @@
     <item-detail-price-box :itemDetail="itemDetail"></item-detail-price-box>
     <custom-swiper :navigatorButtonNames="swiperNavigatorButtonNames">
       <swiper-slide>
-        <item-detail-overall-content :itemDetail="itemDetail" :excludingHeight="210"></item-detail-overall-content>
+        <item-detail-overall-content :itemDetail="itemDetail" :news="news" :excludingHeight="210"></item-detail-overall-content>
       </swiper-slide>
-      <swiper-slide>
+      <!-- <swiper-slide>
         <item-detail-overall-content :itemDetail="itemDetail" :excludingHeight="210"></item-detail-overall-content>
-      </swiper-slide>
+      </swiper-slide> -->
     </custom-swiper>
     <bottom-naviagtor :navigatorButtonNames="bottomNavigatorButtonNames"></bottom-naviagtor>
   </div>
@@ -24,8 +24,6 @@ import MultipurposeHeader from '../components/MultipurposeHeader.vue';
 import ItemDetailPriceBox from '../components/ItemDetailPriceBox.vue';
 import CustomSwiper from '../components/CustomSwiper.vue';
 import ItemDetailOverallContent from '../components/ItemDetailOverallContent.vue';
-
-import { getNews } from '../../frontend/apis';
 
 export default {
   name: 'ItemDetail',
@@ -49,16 +47,18 @@ export default {
   computed: {
     ...mapState({
       itemDetail: (state) => state.itemDetail.itemDetail,
+      news: (state) => state.itemDetail.news,
     }),
   },
 
   methods: {
-    ...mapActions('itemDetail', ['getItemDetail']),
+    ...mapActions('itemDetail', ['getItemDetail', 'getNews']),
   },
 
   async mounted() {
     // const { symbols } = this.$route.query;
     await this.getItemDetail({ symbols: 'AAPL' });
+    await this.getNews({ offset: 0, limit: 3 });
   },
 };
 </script>

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -4,7 +4,12 @@
     <item-detail-price-box :itemDetail="itemDetail"></item-detail-price-box>
     <custom-swiper :navigatorButtonNames="swiperNavigatorButtonNames">
       <swiper-slide>
-        <item-detail-overall-content :itemDetail="itemDetail" :news="news" :excludingHeight="210"></item-detail-overall-content>
+        <item-detail-overall-content
+          :itemDetail="itemDetail"
+          :news="news"
+          :analyses="analyses"
+          :excludingHeight="210"
+        ></item-detail-overall-content>
       </swiper-slide>
       <!-- <swiper-slide>
         <item-detail-overall-content :itemDetail="itemDetail" :excludingHeight="210"></item-detail-overall-content>
@@ -48,17 +53,19 @@ export default {
     ...mapState({
       itemDetail: (state) => state.itemDetail.itemDetail,
       news: (state) => state.itemDetail.news,
+      analyses: (state) => state.itemDetail.analyses,
     }),
   },
 
   methods: {
-    ...mapActions('itemDetail', ['getItemDetail', 'getNews']),
+    ...mapActions('itemDetail', ['getItemDetail', 'getNews', 'getAnalyses']),
   },
 
   async mounted() {
-    // const { symbols } = this.$route.query;
-    await this.getItemDetail({ symbols: 'AAPL' });
+    const { symbols } = this.$route.query;
+    await this.getItemDetail({ symbols });
     await this.getNews({ offset: 0, limit: 3 });
+    await this.getAnalyses({ offset: 0, limit: 3 });
   },
 };
 </script>

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -25,6 +25,8 @@ import ItemDetailPriceBox from '../components/ItemDetailPriceBox.vue';
 import CustomSwiper from '../components/CustomSwiper.vue';
 import ItemDetailOverallContent from '../components/ItemDetailOverallContent.vue';
 
+import { getNews } from '../../frontend/apis';
+
 export default {
   name: 'ItemDetail',
   components: {
@@ -55,8 +57,8 @@ export default {
   },
 
   async mounted() {
-    const { symbols } = this.$route.query;
-    await this.getItemDetail({ symbols });
+    // const { symbols } = this.$route.query;
+    await this.getItemDetail({ symbols: 'AAPL' });
   },
 };
 </script>

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -58,11 +58,11 @@ export default {
     ...mapActions('itemDetail', ['getItemDetail', 'getNews', 'getAnalyses']),
   },
 
-  async mounted() {
+  created() {
     const { symbols } = this.$route.query;
-    await this.getItemDetail({ symbols });
-    await this.getNews({ offset: 0, limit: 3 });
-    await this.getAnalyses({ offset: 0, limit: 3 });
+    this.getItemDetail({ symbols });
+    this.getNews({ offset: 0, limit: 3 });
+    this.getAnalyses({ offset: 0, limit: 3 });
   },
 };
 </script>

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -27,18 +27,14 @@ export class ApiController {
       const token = request.cookies['jwt-token'];
 
       if (!token) {
-        response.sendStatus(401);
-
-        return false;
+        return response.sendStatus(401);
       }
 
       const decodedToken = this.authService.verifyToken(token);
       const user = await this.userService.loginUserByEmail(decodedToken);
 
       if (user) {
-        response.status(200).send(user);
-
-        return true;
+        return response.status(200).send(user);
       }
 
       response.sendStatus(404);
@@ -53,9 +49,7 @@ export class ApiController {
       const user = await this.userService.createUser(reqeust.body);
 
       if (user) {
-        response.sendStatus(200);
-
-        return true;
+        return response.sendStatus(200);
       }
 
       response.sendStatus(409);
@@ -73,9 +67,8 @@ export class ApiController {
 
       if (token) {
         response.cookie('jwt-token', token, { expires: new Date(Date.now() + 9000000), httpOnly: true });
-        response.status(200).send(user);
 
-        return true;
+        return response.status(200).send(user);
       }
 
       response.sendStatus(401);
@@ -93,9 +86,8 @@ export class ApiController {
 
       if (token) {
         response.cookie('jwt-token', token, { expires: new Date(Date.now() + 9000000), httpOnly: true });
-        response.status(200).send(user);
 
-        return true;
+        return response.status(200).send(user);
       }
 
       response.sendStatus(401);
@@ -118,9 +110,7 @@ export class ApiController {
       const stocks = await this.marketService.getStocks();
 
       if (stocks) {
-        resposne.status(200).send(stocks);
-
-        return true;
+        return resposne.status(200).send(stocks);
       }
 
       resposne.sendStatus(404);
@@ -171,9 +161,7 @@ export class ApiController {
       const itemDetailInfo = await this.itemDetailService.getItemDetail({ symbols });
 
       if (itemDetailInfo) {
-        resposne.status(200).send(itemDetailInfo);
-
-        return true;
+        return resposne.status(200).send(itemDetailInfo);
       }
 
       resposne.sendStatus(404);
@@ -196,9 +184,7 @@ export class ApiController {
       const items = await this.searchService.getSearchedItems({ keyword });
 
       if (items) {
-        response.status(200).send(items);
-
-        return true;
+        return response.status(200).send(items);
       }
 
       response.sendStatus(404);
@@ -243,9 +229,7 @@ export class ApiController {
       const news = await this.articleService.getNews(request.body);
 
       if (news) {
-        response.status(200).send(news);
-
-        return true;
+        return response.status(200).send(news);
       }
 
       response.sendStatus(404);
@@ -266,9 +250,7 @@ export class ApiController {
       const analyses = await this.articleService.getOpinions(request.body);
 
       if (analyses) {
-        response.status(200).send(analyses);
-
-        return true;
+        return response.status(200).send(analyses);
       }
 
       response.sendStatus(404);

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -7,7 +7,8 @@ import AuthService from '../../service/AuthService';
 import SearchService from '../../../../common/backend/service/SearchService';
 import MarketService from '../../service/MarketService';
 import ItemDetailService from '../../../../common/backend/service/ItemDetailService';
-import ArticleService from '../../service/ArticleService';
+// import ArticleService from '../../service/ArticleService';
+import ArticleService from '../../../../common/backend/service/ArticleService';
 
 @Controller({ path: '/api' })
 export class ApiController {
@@ -207,20 +208,47 @@ export class ApiController {
     }
   }
 
-  @PostMapping({ path: '/articles' })
-  public async createArticles(request: Request, response: Response) {
-    try {
-      const result = await this.articleService.createArticles(request.body);
+  /**
+   * @description articles를 parsing하여 DB에 document들로 저장하는 controller(common에 추가할 때까지 주석처리)
+   * @param request
+   * @param response
+   * @returns
+   */
+  // @PostMapping({ path: '/articles' })
+  // public async createArticles(request: Request, response: Response) {
+  //   try {
+  //     const result = await this.articleService.createArticles(request.body);
 
-      if (result) {
-        response.sendStatus(200);
+  //     if (result) {
+  //       response.sendStatus(200);
+
+  //       return true;
+  //     }
+  //     response.sendStatus(409);
+  //   } catch (error) {
+  //     console.log(error);
+  //     response.status(500).json(error);
+  //   }
+  // }
+
+  /**
+   * @description DB에서 articles 중 news만 가져오는 controller
+   * @param request
+   * @param response
+   * @returns
+   */
+  @GetMapping({ path: '/articles/news' })
+  public async getNews(request: Request, response: Response) {
+    try {
+      const news = await this.articleService.getNews(request.body);
+
+      if (news) {
+        response.status(200).send(news);
 
         return true;
       }
-      response.sendStatus(409);
     } catch (error) {
       console.log(error);
-      response.status(500).json(error);
     }
   }
 }

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -247,6 +247,31 @@ export class ApiController {
 
         return true;
       }
+
+      response.sendStatus(404);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  /**
+   * @description DB에서 articles 중 analyses만 가져오는 controller
+   * @param request
+   * @param response
+   * @returns
+   */
+  @GetMapping({ path: '/articles/analyses' })
+  public async getAnalyses(request: Request, response: Response) {
+    try {
+      const analyses = await this.articleService.getOpinions(request.body);
+
+      if (analyses) {
+        response.status(200).send(analyses);
+
+        return true;
+      }
+
+      response.sendStatus(404);
     } catch (error) {
       console.log(error);
     }

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -7,6 +7,7 @@ import AuthService from '../../service/AuthService';
 import SearchService from '../../../../common/backend/service/SearchService';
 import MarketService from '../../service/MarketService';
 import ItemDetailService from '../../../../common/backend/service/ItemDetailService';
+import ArticleService from '../../service/ArticleService';
 
 @Controller({ path: '/api' })
 export class ApiController {
@@ -16,6 +17,7 @@ export class ApiController {
     @Inject(SearchService) private searchService: SearchService,
     @Inject(MarketService) private marketService: MarketService,
     @Inject(ItemDetailService) private itemDetailService: ItemDetailService,
+    @Inject(ArticleService) private articleService: ArticleService,
   ) {}
 
   @GetMapping({ path: '/user' })
@@ -202,6 +204,23 @@ export class ApiController {
     } catch (error) {
       console.log(error);
       response.status(404).json(error);
+    }
+  }
+
+  @PostMapping({ path: '/articles' })
+  public async createArticles(request: Request, response: Response) {
+    try {
+      const result = await this.articleService.createArticles(request.body);
+
+      if (result) {
+        response.sendStatus(200);
+
+        return true;
+      }
+      response.sendStatus(409);
+    } catch (error) {
+      console.log(error);
+      response.status(500).json(error);
     }
   }
 }

--- a/packages/karl/backend/service/ArticleService.ts
+++ b/packages/karl/backend/service/ArticleService.ts
@@ -1,0 +1,21 @@
+import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import Article from '../../../common/backend/model/ArticleModel';
+
+@Service()
+export default class ArticleService {
+  constructor() {}
+
+  public async createArticles({ articles }) {
+    await articles.forEach(async (article) => {
+      const { image_url, title, text, source, date, tickers, type } = article;
+
+      const result = await Article.create({ image_url, title, text, source, date, tickers, type });
+
+      if (!result) {
+        throw new Error('Article was not created in DB');
+      }
+    });
+
+    return true;
+  }
+}

--- a/packages/karl/backend/service/MarketService.ts
+++ b/packages/karl/backend/service/MarketService.ts
@@ -12,7 +12,7 @@ export default class MarketService {
    */
   public async getStocks() {
     const { accessKey } = marketStackConfig;
-    let stocks = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}`)).data;
+    const { data: stocks } = await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}`);
 
     if (stocks) {
       return stocks;

--- a/packages/karl/backend/service/MarketService.ts
+++ b/packages/karl/backend/service/MarketService.ts
@@ -11,38 +11,24 @@ export default class MarketService {
    * @returns stock과 pagination을 담은 Object
    */
   public async getStocks() {
-    try {
-      const { accessKey } = marketStackConfig;
-      let stocks = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}`)).data;
+    const { accessKey } = marketStackConfig;
+    let stocks = await (await axios.get(`http://api.marketstack.com/v1/tickers?access_key=${accessKey}`)).data;
 
-      if (stocks) {
-        return stocks;
-      }
-
-      throw new Error('getting stocks was failed in MarketService');
-    } catch (error) {
-      console.log(error);
+    if (stocks) {
+      return stocks;
     }
+
+    throw new Error('getting stocks was failed in MarketService');
   }
 
   /**
    * @description home page에 렌더링할 indices를 가져오는 service
    */
 
-  public async getIndices() {
-    try {
-    } catch (error) {
-      console.log(error);
-    }
-  }
+  public async getIndices() {}
 
   /**
    * @description home page에 렌더링할 crypto currencies를 가져오는 service
    */
-  public async getCryptoCurrencies() {
-    try {
-    } catch (error) {
-      console.log(error);
-    }
-  }
+  public async getCryptoCurrencies() {}
 }

--- a/packages/karl/frontend/apis/index.ts
+++ b/packages/karl/frontend/apis/index.ts
@@ -52,6 +52,22 @@ const createUser = async ({ name, email, password, googleId }: createUserInfo) =
   }
 };
 
+const createArticles = async ({ articles }) => {
+  try {
+    const result = await Axios.post(`${devURL}/api/articles`, {
+      articles,
+    });
+
+    if (result) {
+      return result;
+    }
+
+    throw new Error('Articles were not created');
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 const getUser = async () => {
   try {
     const result = await Axios.get(`${devURL}/api/user`, { withCredentials: true });
@@ -137,4 +153,13 @@ const getCryptoCurrencies = async () => {
   }
 };
 
-export { createUser, loginUserByEmail, getUser, loginUserByGoogleOAuth, getStocks, getIndices, getCryptoCurrencies };
+export {
+  createUser,
+  loginUserByEmail,
+  getUser,
+  loginUserByGoogleOAuth,
+  getStocks,
+  getIndices,
+  getCryptoCurrencies,
+  createArticles,
+};

--- a/packages/karl/frontend/apis/index.ts
+++ b/packages/karl/frontend/apis/index.ts
@@ -57,11 +57,9 @@ const createArticles = async ({ articles }) => {
     const result = await Axios.post(`${devURL}/api/articles`, {
       articles,
     });
-
     if (result) {
       return result;
     }
-
     throw new Error('Articles were not created');
   } catch (error) {
     console.log(error);

--- a/packages/karl/frontend/router/index.ts
+++ b/packages/karl/frontend/router/index.ts
@@ -15,7 +15,7 @@ export default () => {
 
     routes: [
       {
-        path: '/ssss',
+        path: '/',
         name: 'Login',
         component: Login,
       },
@@ -30,7 +30,7 @@ export default () => {
         component: Home,
       },
       {
-        path: '/',
+        path: '/item-detail',
         name: 'ItemDetail',
         component: ItemDetail,
       },

--- a/packages/karl/frontend/router/index.ts
+++ b/packages/karl/frontend/router/index.ts
@@ -25,12 +25,12 @@ export default () => {
         component: Signup,
       },
       {
-        path: '/',
+        path: '/home',
         name: 'Home',
         component: Home,
       },
       {
-        path: '/item-detail',
+        path: '/',
         name: 'ItemDetail',
         component: ItemDetail,
       },

--- a/packages/karl/frontend/views/Home.vue
+++ b/packages/karl/frontend/views/Home.vue
@@ -50,7 +50,9 @@ export default {
     ...mapActions('market', ['getStocks']),
   },
 
-  async mounted() {},
+  async mounted() {
+    await this.getStocks();
+  },
 };
 </script>
 

--- a/packages/karl/frontend/views/Home.vue
+++ b/packages/karl/frontend/views/Home.vue
@@ -20,6 +20,7 @@ import ItemCardList from '../../../common/frontend/components/ItemCardList.vue';
 import CustomSwiper from '../../../common/frontend/components/CustomSwiper.vue';
 
 import { text } from '../../../common/frontend/constants';
+import { createArticles } from '../apis';
 
 export default {
   name: 'Home',
@@ -50,9 +51,7 @@ export default {
     ...mapActions('market', ['getStocks']),
   },
 
-  mounted() {
-    this.getStocks();
-  },
+  async mounted() {},
 };
 </script>
 

--- a/packages/karl/frontend/views/Home.vue
+++ b/packages/karl/frontend/views/Home.vue
@@ -20,7 +20,6 @@ import ItemCardList from '../../../common/frontend/components/ItemCardList.vue';
 import CustomSwiper from '../../../common/frontend/components/CustomSwiper.vue';
 
 import { text } from '../../../common/frontend/constants';
-import { createArticles } from '../apis';
 
 export default {
   name: 'Home',


### PR DESCRIPTION
## 작업내용
* articles 데이터 DB에 추가
* createArticle service 추가
* SubContentBox 컴포넌트 추가
* overview, news, analysis 컨텐츠를 적절히 렌더링하는 로직 추가 (백엔드 연동)
* trycatch문 삭제, scrollbar 숨김 등 리팩토링

## todo
* 종목 상세페이지에 opnion(의견) 컨텐츠 렌더링 로직 추가
* 종목 상세페이지에 차트 추가
* 속도 개선을 위한 cache 로직 추가
* historicla data 난수화 생성 로직 추가
* 컴포넌트들 사용하기 위한 간략한 docs 추가
* 리팩토링

![Animation](https://user-images.githubusercontent.com/41279460/120297108-bd1c5180-c303-11eb-9ffd-175c7c7e7414.gif)
