### PR TITLE
Implement list sorting

### DIFF
--- a/packages/dogyeong/src/frontend/components/Market/MarketCoin.vue
+++ b/packages/dogyeong/src/frontend/components/Market/MarketCoin.vue
@@ -6,30 +6,34 @@
     <div v-else-if="isError">
       Error!
     </div>
-    <MarketList v-else :list-data="coins"></MarketList>
+    <MarketList
+      v-else
+      :listData="sortedMarketData"
+      :sortByValue="sortByValue"
+      :sortByDiff="sortByDiff"
+      @clickValueTab="changeSortByValue"
+      @clickDiffTab="changeSrotByDiff"
+    ></MarketList>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { mapState } from 'vuex';
-import MarketList from '@/components/MarketList/MarketList.vue';
+import MarketList from '@/components/Market/MarketList.vue';
+import sortMixin from '@/mixin/sortMixin';
 
 export default Vue.extend({
   name: 'MarketCoin',
 
   components: { MarketList },
 
+  mixins: [sortMixin],
+
   computed: {
-    ...mapState({ coins: ({ finance }) => finance.coins.data }),
+    ...mapState({ marketData: ({ finance }) => finance.coins.data }),
     ...mapState({ isLoading: ({ finance }) => finance.coins.isLoading }),
     ...mapState({ isError: ({ finance }) => finance.coins.isError }),
   },
 });
 </script>
-
-<style scoped>
-h2 {
-  background-color: aqua;
-}
-</style>

--- a/packages/dogyeong/src/frontend/components/Market/MarketIndex.vue
+++ b/packages/dogyeong/src/frontend/components/Market/MarketIndex.vue
@@ -6,22 +6,32 @@
     <div v-else-if="isError">
       Error!
     </div>
-    <MarketList v-else :list-data="indices"></MarketList>
+    <MarketList
+      v-else
+      :listData="sortedMarketData"
+      :sortByValue="sortByValue"
+      :sortByDiff="sortByDiff"
+      @clickValueTab="changeSortByValue"
+      @clickDiffTab="changeSrotByDiff"
+    ></MarketList>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { mapState } from 'vuex';
-import MarketList from '@/components/MarketList/MarketList.vue';
+import MarketList from '@/components/Market/MarketList.vue';
+import sortMixin from '@/mixin/sortMixin';
 
 export default Vue.extend({
   name: 'MarketIndex',
 
   components: { MarketList },
 
+  mixins: [sortMixin],
+
   computed: {
-    ...mapState({ indices: ({ finance }) => finance.indices.data }),
+    ...mapState({ marketData: ({ finance }) => finance.indices.data }),
     ...mapState({ isLoading: ({ finance }) => finance.indices.isLoading }),
     ...mapState({ isError: ({ finance }) => finance.indices.isError }),
   },

--- a/packages/dogyeong/src/frontend/components/Market/MarketList.vue
+++ b/packages/dogyeong/src/frontend/components/Market/MarketList.vue
@@ -4,27 +4,22 @@
       <thead>
         <tr>
           <th>이름</th>
-          <th>현재가</th>
-          <th>전일대비</th>
+          <th @click="$emit('clickValueTab')">현재가{{ sortByValue | formatSortText }}</th>
+          <th @click="$emit('clickDiffTab')">전일대비{{ sortByDiff | formatSortText }}</th>
         </tr>
       </thead>
       <tbody>
-        <RouterLink
-          :to="`/market/stock/${key}`"
-          v-for="{ key, date, diff, growthRate, value } in listData"
-          :key="key"
-          :style="itemStyle"
-        >
+        <RouterLink :to="`/market/stock/${key}`" v-for="{ key, date, diff, growthRate, value } in listData" :key="key">
           <tr>
             <td>
-              <h4 :style="titleStyle">{{ key }}</h4>
-              <span :style="dateStyle">{{ date }}</span>
+              <h4>{{ key }}</h4>
+              <span class="date">{{ date | formatDate }}</span>
             </td>
             <td>
-              <span class="value" :class="getColorClass(diff)" :style="valueStyle">{{ value }}</span>
+              <span class="value" :class="getColorClass(diff)">{{ value }}</span>
             </td>
             <td>
-              <span class="diff" :class="getColorClass(diff)" :style="diffStyle">
+              <span class="diff" :class="getColorClass(diff)">
                 {{ diff | formatNumber }}
                 {{ growthRate | formatNumber | formatPercent }}
               </span>
@@ -38,17 +33,15 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { sortMap } from '@/mixin/sortMixin';
 
 /**
  * 시장 탭에서 사용하는 리스트 컴포넌트
  * 지수, 주식, 가상화폐의 현재 시세를 보여준다
  *
- * @property {MarketListItem[]} listDate 아래의 MarketListItem 인터페이스 참고
- * @property {object} itemStyle 하나의 row에 해당하는 li태그 스타일
- * @property {object} titleStyle 종목 이름 스타일
- * @property {object} dateStyle 종목 이름 아래의 날짜 부분 스타일
- * @property {object} valueStyle 현재 값 부분 스타일
- * @property {object} diffStyle 값 아래의 변동값 스타일
+ * @prop {MarketListItem[]} listData 아래의 MarketListItem 인터페이스 참고
+ * @prop {number} sortByValue 현재가 정렬 기준 @see @/mixin/sortMixin#sortMap
+ * @prop {number} sortByDiff 전일대비 정렬 기준 @see @/mixin/sortMixin#sortMap
  */
 
 export interface MarketListItem {
@@ -70,6 +63,14 @@ export default Vue.extend({
     formatPercent(value: number) {
       return `(${value}%)`;
     },
+    formatSortText(sortBy: number) {
+      if (sortBy === sortMap.desc) return '(내림)';
+      if (sortBy === sortMap.asc) return '(오름)';
+      return '';
+    },
+    formatDate(date: string) {
+      return date.replaceAll('-', '. ');
+    },
   },
 
   props: {
@@ -77,25 +78,13 @@ export default Vue.extend({
       type: Array,
       required: true,
     },
-    itemStyle: {
-      type: Object,
-      default: () => ({}),
+    sortByValue: {
+      type: Number,
+      default: sortMap.none,
     },
-    titleStyle: {
-      type: Object,
-      default: () => ({}),
-    },
-    dateStyle: {
-      type: Object,
-      default: () => ({}),
-    },
-    valueStyle: {
-      type: Object,
-      default: () => ({}),
-    },
-    diffStyle: {
-      type: Object,
-      default: () => ({}),
+    sortByDiff: {
+      type: Number,
+      default: sortMap.none,
     },
   },
 
@@ -128,6 +117,11 @@ table {
 
   td {
     padding: 6px 12px;
+
+    .date {
+      color: var(--sub-text-color);
+      font-size: 15px;
+    }
   }
 
   th:first-child,

--- a/packages/dogyeong/src/frontend/components/Market/MarketStock.vue
+++ b/packages/dogyeong/src/frontend/components/Market/MarketStock.vue
@@ -6,22 +6,32 @@
     <div v-else-if="isError">
       Error!
     </div>
-    <MarketList v-else :list-data="stocks"></MarketList>
+    <MarketList
+      v-else
+      :listData="sortedMarketData"
+      :sortByValue="sortByValue"
+      :sortByDiff="sortByDiff"
+      @clickValueTab="changeSortByValue"
+      @clickDiffTab="changeSrotByDiff"
+    ></MarketList>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { mapState } from 'vuex';
-import MarketList from '@/components/MarketList/MarketList.vue';
+import MarketList from '@/components/Market/MarketList.vue';
+import sortMixin from '@/mixin/sortMixin';
 
 export default Vue.extend({
   name: 'MarketStock',
 
   components: { MarketList },
 
+  mixins: [sortMixin],
+
   computed: {
-    ...mapState({ stocks: ({ finance }) => finance.stocks.data }),
+    ...mapState({ marketData: ({ finance }) => finance.stocks.data }),
     ...mapState({ isLoading: ({ finance }) => finance.stocks.isLoading }),
     ...mapState({ isError: ({ finance }) => finance.stocks.isError }),
   },

--- a/packages/dogyeong/src/frontend/components/MarketList/MarketList.vue
+++ b/packages/dogyeong/src/frontend/components/MarketList/MarketList.vue
@@ -1,19 +1,39 @@
 <template>
-  <ul>
-    <li v-for="data in listData" :key="data.key" :style="itemStyle">
-      <div>
-        <h4 :style="titleStyle">{{ data.key }}</h4>
-        <span :style="dateStyle">{{ data.date }}</span>
-      </div>
-      <div>
-        <span class="value" :style="valueStyle">{{ data.value }}</span>
-        <span class="diff" :class="getColorClass(data.diff)" :style="diffStyle">
-          {{ data.diff | formatNumber }}
-          {{ data.growthRate | formatNumber | formatPercent }}
-        </span>
-      </div>
-    </li>
-  </ul>
+  <div>
+    <table>
+      <thead>
+        <tr>
+          <th>이름</th>
+          <th>현재가</th>
+          <th>전일대비</th>
+        </tr>
+      </thead>
+      <tbody>
+        <RouterLink
+          :to="`/market/stock/${key}`"
+          v-for="{ key, date, diff, growthRate, value } in listData"
+          :key="key"
+          :style="itemStyle"
+        >
+          <tr>
+            <td>
+              <h4 :style="titleStyle">{{ key }}</h4>
+              <span :style="dateStyle">{{ date }}</span>
+            </td>
+            <td>
+              <span class="value" :class="getColorClass(diff)" :style="valueStyle">{{ value }}</span>
+            </td>
+            <td>
+              <span class="diff" :class="getColorClass(diff)" :style="diffStyle">
+                {{ diff | formatNumber }}
+                {{ growthRate | formatNumber | formatPercent }}
+              </span>
+            </td>
+          </tr>
+        </RouterLink>
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <script lang="ts">
@@ -90,37 +110,45 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-ul {
-  li {
+table {
+  width: 100%;
+  height: 100%;
+  font-size: 1rem;
+
+  a {
     padding: 8px 12px;
-    display: flex;
+    display: contents;
     justify-content: space-between;
     border-bottom: 1px solid var(--border-color);
+  }
 
-    h4 {
-      font-size: 1.2rem;
+  th {
+    padding: 12px;
+  }
+
+  td {
+    padding: 6px 12px;
+  }
+
+  th:first-child,
+  td:first-child {
+    text-align: left;
+  }
+
+  th,
+  td {
+    vertical-align: middle;
+    text-align: right;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .value,
+  .diff {
+    &.red {
+      color: var(--red-color);
     }
-
-    .value,
-    .diff {
-      display: block;
-      text-align: right;
-    }
-
-    .value {
-      font-size: 1.2rem;
-    }
-
-    .diff {
-      font-size: 1rem;
-      font-weight: bold;
-
-      &.red {
-        color: var(--red-color);
-      }
-      &.blue {
-        color: var(--blue-color);
-      }
+    &.blue {
+      color: var(--blue-color);
     }
   }
 }

--- a/packages/dogyeong/src/frontend/mixin/sortMixin.ts
+++ b/packages/dogyeong/src/frontend/mixin/sortMixin.ts
@@ -1,0 +1,42 @@
+export const sortMap = {
+  desc: -1,
+  asc: 1,
+  none: 0,
+} as const;
+
+export default {
+  data() {
+    return {
+      sortByValue: sortMap.none,
+      sortByDiff: sortMap.none,
+    };
+  },
+
+  computed: {
+    sortedMarketData() {
+      if (this.sortByValue === sortMap.asc || this.sortByValue === sortMap.desc) {
+        return [...this.marketData].sort((a, b) => (a.value - b.value) * this.sortByValue);
+      }
+      if (this.sortByDiff === 1 || this.sortByDiff === -1) {
+        return [...this.marketData].sort((a, b) => (a.diff - b.diff) * this.sortByDiff);
+      }
+      return this.marketData;
+    },
+  },
+
+  methods: {
+    changeSortByValue() {
+      this.sortByDiff = sortMap.none;
+      if (this.sortByValue === sortMap.none) return (this.sortByValue = sortMap.desc);
+      if (this.sortByValue === sortMap.desc) return (this.sortByValue = sortMap.asc);
+      this.sortByValue = sortMap.none;
+    },
+
+    changeSrotByDiff() {
+      this.sortByValue = sortMap.none;
+      if (this.sortByDiff === sortMap.none) return (this.sortByDiff = sortMap.desc);
+      if (this.sortByDiff === sortMap.desc) return (this.sortByDiff = sortMap.asc);
+      this.sortByDiff = sortMap.none;
+    },
+  },
+};

--- a/packages/dogyeong/tsconfig.frontend.json
+++ b/packages/dogyeong/tsconfig.frontend.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "allowJs": true
+    "allowJs": true,
+    "lib": ["esnext"]
   },
 
   "exclude": ["**/backend/**", "**/node_modules/**"]


### PR DESCRIPTION
## 작업내용

- MarketList 컴포넌트에서 정렬기능 구현
  - HTML 마크업 변경(ul -> table)
  - sortMixin 추가: 지수, 주식, 가상화폐 페이지에서 공통적으로 쓰는 정렬기능 구현

## Screenshots

![Animation](https://user-images.githubusercontent.com/40662323/120452944-8f034400-c3cd-11eb-8710-6c3cb0870ddc.gif)
