### PR TITLE
Feat: 거래량 차트 추가, 가격구분선 리팩토링

### DIFF
--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -52,6 +52,7 @@ export type adjustedData = {
  * @property `duration`? 평균낼 기간, default 20
  */
 export interface SMAOptions {
+  ratio: number;
   color: string;
   duration: number;
   width?: number;
@@ -65,6 +66,7 @@ export interface DrawLinePaths {
 }
 
 export interface DrawLineOptions {
+  ratio: number;
   color?: string;
   lineWidth?: number;
 }
@@ -74,6 +76,7 @@ export interface DrawTextRequired {
   centerX: number;
   centerY: number;
   canvasHeight: number;
+  ratio: number;
 }
 
 export interface DrawTextOptions {
@@ -129,13 +132,19 @@ export interface DayPartitionOptions {
   canvasHeight: number;
   /** 원점 Y 좌표 */
   zeroY: number;
+  ratio: number;
 }
 
 export interface PricePartitionOptions {
   highest: number;
   lowest: number;
   zeroY: number;
+  ratio: number;
   ratioH: number;
   canvasWidth: number;
   canvasHeight: number;
+  partNum?: number;
+  textAlign?: CanvasTextAlign;
+  textBaseline?: CanvasTextBaseline;
+  fontSize?: number;
 }

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -94,6 +94,8 @@ export interface ClientWH {
 
 export interface refinerOptions extends Omit<ClientWH, 'ratio'> {
   count: number;
+  ratioH: number;
+  lowest: number;
   range: Generator<number, void, any>;
   total?: number;
   customNumToShow?: number;
@@ -127,4 +129,13 @@ export interface DayPartitionOptions {
   canvasHeight: number;
   /** 원점 Y 좌표 */
   zeroY: number;
+}
+
+export interface PricePartitionOptions {
+  highest: number;
+  lowest: number;
+  zeroY: number;
+  ratioH: number;
+  canvasWidth: number;
+  canvasHeight: number;
 }

--- a/packages/wiii/frontend/utils/chart/candle.ts
+++ b/packages/wiii/frontend/utils/chart/candle.ts
@@ -4,7 +4,7 @@ import { initCanvas } from '@/utils/chart/init';
 import { setSMA } from '@/utils/chart/sma';
 
 import { range } from '../../../domain/utilFunc';
-import { refiner, setDayPartition } from './position';
+import { getHeightRatio, refiner, setDayPartition, setPricePartition } from './position';
 
 /**
  * drawBasicCandleChart
@@ -21,11 +21,15 @@ export const drawBasicCandleChart = ({
 }: DrawCandleChartOptions): object => {
   const { zeroX, zeroY, ratio, canvasWidth, canvasHeight } = initCanvas(ctx);
 
+  const { ratioH, lowest, highest } = getHeightRatio(results, zeroY);
+
   /** 캔버스 그리기 쉽게 데이터 전처리 */
   const { data, candleWidth, numToShow } = refiner(results, {
     zeroX,
     zeroY,
     count,
+    ratioH,
+    lowest,
     range: range(0, count),
     customNumToShow,
   });
@@ -39,6 +43,9 @@ export const drawBasicCandleChart = ({
   for (const { duration, color, width } of smaConfigs) {
     setSMA(ctx, data, { duration, color, width });
   }
+
+  /** 가격 구분선 */
+  setPricePartition(ctx, { highest, lowest, zeroY, ratioH, canvasWidth, canvasHeight });
 
   /** 일자구분선 */
   setDayPartition(ctx, { data, results, numToShow, count, canvasWidth, canvasHeight, zeroY });

--- a/packages/wiii/frontend/utils/chart/drawers.ts
+++ b/packages/wiii/frontend/utils/chart/drawers.ts
@@ -11,8 +11,8 @@ export const drawText = (
 ) => {
   ctx.save();
   ctx.strokeStyle = CandleColorEnum.grey900;
-  ctx.font = `${fontSize ?? canvasHeight * 0.014}px ${fontFamily ?? `sans-serif`}`;
   ctx.textBaseline = textBaseline ?? 'bottom';
+  ctx.font = `${fontSize ?? `25px/30`}px ${fontFamily ?? `sans-serif`}`;
   ctx.textAlign = textAlign ?? 'right';
   ctx.fillText(text, centerX, centerY);
   ctx.strokeText(text, centerX, centerY);

--- a/packages/wiii/frontend/utils/chart/drawers.ts
+++ b/packages/wiii/frontend/utils/chart/drawers.ts
@@ -1,4 +1,5 @@
 import { CandleColorEnum, DrawLineOptions, DrawLinePaths, DrawTextOptions, DrawTextRequired, RefinedCandle } from '@/type/chart';
+import { CandleOne } from '../../../domain/marketData';
 
 /** @description ctx.rotate() 사용시 필요 */
 const { PI } = Math;
@@ -6,7 +7,7 @@ const BASE_RADIAN = PI / 180;
 
 export const drawText = (
   ctx: CanvasRenderingContext2D,
-  { text, centerX, centerY, canvasHeight }: DrawTextRequired,
+  { text, centerX, centerY, ratio }: DrawTextRequired,
   { fontFamily, fontSize, textBaseline, textAlign, /** @todo 쓰기 애매해서 뺄수도 */ textWidth }: DrawTextOptions,
 ) => {
   ctx.save();
@@ -16,13 +17,14 @@ export const drawText = (
   ctx.textAlign = textAlign ?? 'right';
   ctx.fillText(text, centerX, centerY);
   ctx.strokeText(text, centerX, centerY);
+  ctx.scale(ratio, ratio);
   ctx.restore();
 };
 
 export const drawLine = (
   ctx: CanvasRenderingContext2D,
   { beginX, beginY, lastX, lastY }: DrawLinePaths,
-  { color, lineWidth }: DrawLineOptions,
+  { ratio, color, lineWidth }: DrawLineOptions,
 ) => {
   ctx.save();
   ctx.strokeStyle = color || CandleColorEnum.grey900;
@@ -32,6 +34,7 @@ export const drawLine = (
   ctx.lineTo(lastX, lastY);
   ctx.closePath();
   ctx.stroke();
+  ctx.scale(ratio, ratio);
   ctx.restore();
 };
 
@@ -45,16 +48,25 @@ export const drawCandle = (
   ctx.save();
 
   /** 캔들 꼬리 */
-  drawLine(ctx, { beginX: centerX, beginY: highY, lastX: centerX, lastY: lowY }, { color });
+  drawLine(ctx, { beginX: centerX, beginY: highY, lastX: centerX, lastY: lowY }, { ratio, color });
 
   /** 캔들 몸통 */
   if (rectH === 0) {
-    drawLine(ctx, { beginX: startX, beginY: openY, lastX: startX + candleWidth, lastY: openY }, {});
+    drawLine(ctx, { beginX: startX, beginY: openY, lastX: startX + candleWidth, lastY: openY }, { ratio });
   } else {
     ctx.fillStyle = color;
     ctx.fillRect(startX, openY, candleWidth, rectH);
   }
 
   ctx.scale(ratio, ratio);
+  ctx.restore();
+};
+
+export const drawVolume = (ctx: CanvasRenderingContext2D, { startX, volume, base, candleWidth, ratio, color }) => {
+  ctx.save();
+  ctx.fillStyle = color;
+  const height = volume * ratio;
+  ctx.fillRect(startX, base - height, candleWidth, height);
+
   ctx.restore();
 };

--- a/packages/wiii/frontend/utils/chart/init.ts
+++ b/packages/wiii/frontend/utils/chart/init.ts
@@ -32,7 +32,7 @@ export const initCanvas = (ctx: CanvasRenderingContext2D): ClientWH => {
 
   /** @todo 좀 이해안가는 부분.. */
   const zeroX = canvasWidth * 0.927;
-  const zeroY = zeroX * 1.1;
+  const zeroY = zeroX * 1.12;
 
   return {
     /** 영점 */

--- a/packages/wiii/frontend/utils/chart/sma.ts
+++ b/packages/wiii/frontend/utils/chart/sma.ts
@@ -21,7 +21,7 @@ const getAvg = (data: RefinedCandle[], start: number, duration: number) =>
 /**
  * setSMA(ctx, data, {duration, color})
  */
-export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { duration, color, width }: SMAOptions) => {
+export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { ratio, duration, color, width }: SMAOptions) => {
   /** 가장 오래된 기간은 제외 */
   const length = data.length - duration;
   if (duration > length) return;
@@ -34,7 +34,7 @@ export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { d
     const { centerX: prevX } = data[i + 1];
     const prevAvg = getAvg(data, i, duration);
 
-    drawLine(ctx, { beginX: curX, beginY: curAvg, lastX: prevX, lastY: prevAvg }, { color, lineWidth: width });
+    drawLine(ctx, { beginX: curX, beginY: curAvg, lastX: prevX, lastY: prevAvg }, { ratio, color, lineWidth: width });
 
     curAvg = prevAvg;
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/57997672/120453548-1c469880-c3ce-11eb-8fac-d228680bd34b.png)

##  Feat: 거래량 차트 추가

- 차트 영역 하단 20%에 거래량 차트 추가
- 기존 코드 최대한 재활용
- 보조 지표 추가되었으나, 렌더링 시간은 크게 차이나지 않음
  - 150% 확대 기준 350ms 내외

## Refactor: 가격구분선 setPricePartition 리팩토링

## TODO => 다음주 시간 나면 다시 진행 예상

- 실제 차트와 미세한 차이 조정 필요
- 종목명 표시, 시고저종가 표시 등 보조 도구
- Mouse, Touch 이벤트
