### PR TITLE
Feat: 컴포넌트 전반 다크모드 적용, 다크모드 전용 색상 추가

### DIFF
--- a/packages/wiii/frontend/App.vue
+++ b/packages/wiii/frontend/App.vue
@@ -9,12 +9,12 @@ export default {
   name: 'App',
 
   computed: {
-    /**
-     * @todo
-     */
     isDark() {
-      // return this.isDark ? 'dark' : null;
-      return null;
+      /**
+       * @todo
+       * 다크 모드 토글
+       */
+      return 'dark';
     },
   },
 };
@@ -27,6 +27,9 @@ html {
   body {
     @extend .reset;
 
+    /** @todo 다크모드 토글 */
+    @extend .dark;
+
     max-width: $max-width-mobile;
     height: 100vh;
     background-color: $grey-100;
@@ -38,6 +41,7 @@ html {
 }
 
 .dark {
-  background-color: $grey-700;
+  background-color: $deep-dark;
+  color: $sup-beige;
 }
 </style>

--- a/packages/wiii/frontend/components/atoms/RouterLink.vue
+++ b/packages/wiii/frontend/components/atoms/RouterLink.vue
@@ -21,7 +21,7 @@ export default Vue.extend({
 
   computed: {
     isDarkTheme() {
-      return this.isDark ? `dark` : ``;
+      return `dark`;
     },
   },
 });
@@ -45,13 +45,12 @@ export default Vue.extend({
 
   &.dark {
     color: $grey-100;
-    text-shadow: 0 0 15px $red-neon;
-    background-color: $grey-700;
-    box-shadow: 0 0 10px $red-neon;
+    text-shadow: 0 0 15px $neon-crimson;
+    box-shadow: 0 0 10px $neon-crimson;
 
     &:hover {
-      background-color: $grey-500;
-      color: $red-neon;
+      background-color: $shallow-blue;
+      color: $neon-crimson;
       font-weight: bold;
     }
   }
@@ -59,7 +58,7 @@ export default Vue.extend({
   &-active,
   &-exact-active {
     &.dark {
-      color: $red-neon;
+      color: $neon-crimson;
     }
   }
 }

--- a/packages/wiii/frontend/components/atoms/Title.vue
+++ b/packages/wiii/frontend/components/atoms/Title.vue
@@ -1,5 +1,5 @@
 <template>
-  <p class="card" :style="{ ...style }">{{ title }}</p>
+  <p class="card" :style="{ ...style }" :class="isDark">{{ title }}</p>
 </template>
 
 <script lang="ts">
@@ -8,10 +8,10 @@ import { blue700 } from '@/styles/index.scss';
 
 export default Vue.extend({
   props: {
-    color: {
-      type: String,
-      default: blue700,
-    },
+    // color: {
+    //   type: String,
+    //   default: blue700,
+    // },
     titleText: {
       type: String,
       default: '',
@@ -29,7 +29,7 @@ export default Vue.extend({
   computed: {
     style() {
       return {
-        color: this.color,
+        // color: this.color,
         fontSize: this.fontSize,
         fontWeight: this.fontWeight,
       };
@@ -37,6 +37,11 @@ export default Vue.extend({
 
     title() {
       return this.titleText;
+    },
+
+    isDark() {
+      /** @todo dark 모드 토글 */
+      return 'card dark';
     },
   },
 });

--- a/packages/wiii/frontend/components/organisms/Chart.vue
+++ b/packages/wiii/frontend/components/organisms/Chart.vue
@@ -1,5 +1,5 @@
 <template>
-  <canvas ref="canvas" class="area"></canvas>
+  <canvas ref="canvas" class="area dark"></canvas>
 </template>
 
 <script lang="ts">
@@ -193,7 +193,10 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 canvas {
-  box-shadow: 0 0 20px 5px $red-neon;
   background-color: white;
+
+  &.dark {
+    box-shadow: 0 0 20px 5px $neon-crimson;
+  }
 }
 </style>

--- a/packages/wiii/frontend/components/organisms/HomeFooter.vue
+++ b/packages/wiii/frontend/components/organisms/HomeFooter.vue
@@ -1,5 +1,16 @@
 <template>
-  <footer class="area">
-    <h3 class="card">Footer</h3>
+  <footer class="area" :class="isDark">
+    <h3 class="card" :class="isDark">Footer</h3>
   </footer>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({
+  computed: {
+    isDark() {
+      return `dark`;
+    },
+  },
+});
+</script>

--- a/packages/wiii/frontend/components/templates/Home.vue
+++ b/packages/wiii/frontend/components/templates/Home.vue
@@ -1,5 +1,16 @@
 <template>
-  <main class="area">
-    <h3 class="card">MAIN SECTION</h3>
+  <main class="area" :class="isDark">
+    <h3 class="card" :class="isDark">MAIN SECTION</h3>
   </main>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({
+  computed: {
+    isDark() {
+      return `dark`;
+    },
+  },
+});
+</script>

--- a/packages/wiii/frontend/styles/_colors.scss
+++ b/packages/wiii/frontend/styles/_colors.scss
@@ -22,8 +22,21 @@ $green-500: rgba(0, 150, 136, 1);
 $green-300: rgba(77, 182, 172, 1);
 $green-100: rgba(178, 223, 219, 1);
 
-$red-neon: rgba(255, 23, 68, 1);
-$cyan-neon: rgba(224, 247, 250, 1);
+// for dark mode
+// super theme 색상 참고 (rainglow)
+// @see https://github.com/rainglow/vscode/blob/master/themes/super.json
+$sup-dark: #2c343d;
+$sup-beige: #ffe792;
+
+// neon colors
+// @see https://colorswall.com/palette/94171
+$neon-crimson: rgba(249, 0, 79, 1);
+$neon-blurple: rgba(114, 137, 218, 1);
+$neon-green: rgba(57, 255, 186, 1);
+$sunny-yellow: rgba(255, 238, 122, 1);
+$deep-dark: rgba(25, 27, 42, 1);
+$deep-blue: rgba(42, 45, 70, 1);
+$shallow-blue: rgba(60, 67, 103, 1);
 
 :export {
   grey900: $grey-900;
@@ -42,5 +55,7 @@ $cyan-neon: rgba(224, 247, 250, 1);
   green500: $green-500;
   green300: $green-300;
   green100: $green-100;
-  red-neon: $red-neon;
+  neonCrimson: $neon-crimson;
+  neonBlurple: $neon-blurple;
+  sunnyYellow: $sunny-yellow;
 }

--- a/packages/wiii/frontend/styles/_variables.scss
+++ b/packages/wiii/frontend/styles/_variables.scss
@@ -26,6 +26,10 @@
   @extend .center;
 
   max-width: $max-width-mobile;
+
+  &.dark {
+    background-color: $deep-dark;
+  }
 }
 
 .card {
@@ -37,6 +41,12 @@
   border-radius: 15px;
   background-color: $white-900;
   color: $grey-900;
+  cursor: pointer;
+
+  &.dark {
+    background-color: $deep-blue;
+    color: $sunny-yellow;
+  }
 }
 
 .router-link {

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -52,6 +52,7 @@ export type adjustedData = {
  * @property `duration`? 평균낼 기간, default 20
  */
 export interface SMAOptions {
+  ratio: number;
   color: string;
   duration: number;
   width?: number;
@@ -65,6 +66,7 @@ export interface DrawLinePaths {
 }
 
 export interface DrawLineOptions {
+  ratio: number;
   color?: string;
   lineWidth?: number;
 }
@@ -74,6 +76,7 @@ export interface DrawTextRequired {
   centerX: number;
   centerY: number;
   canvasHeight: number;
+  ratio: number;
 }
 
 export interface DrawTextOptions {
@@ -129,13 +132,19 @@ export interface DayPartitionOptions {
   canvasHeight: number;
   /** 원점 Y 좌표 */
   zeroY: number;
+  ratio: number;
 }
 
 export interface PricePartitionOptions {
   highest: number;
   lowest: number;
   zeroY: number;
+  ratio: number;
   ratioH: number;
   canvasWidth: number;
   canvasHeight: number;
+  partNum?: number;
+  textAlign?: CanvasTextAlign;
+  textBaseline?: CanvasTextBaseline;
+  fontSize?: number;
 }

--- a/packages/wiii/frontend/type/chart.ts
+++ b/packages/wiii/frontend/type/chart.ts
@@ -94,6 +94,8 @@ export interface ClientWH {
 
 export interface refinerOptions extends Omit<ClientWH, 'ratio'> {
   count: number;
+  ratioH: number;
+  lowest: number;
   range: Generator<number, void, any>;
   total?: number;
   customNumToShow?: number;
@@ -127,4 +129,13 @@ export interface DayPartitionOptions {
   canvasHeight: number;
   /** 원점 Y 좌표 */
   zeroY: number;
+}
+
+export interface PricePartitionOptions {
+  highest: number;
+  lowest: number;
+  zeroY: number;
+  ratioH: number;
+  canvasWidth: number;
+  canvasHeight: number;
 }

--- a/packages/wiii/frontend/utils/chart/candle.ts
+++ b/packages/wiii/frontend/utils/chart/candle.ts
@@ -4,7 +4,7 @@ import { initCanvas } from '@/utils/chart/init';
 import { setSMA } from '@/utils/chart/sma';
 
 import { range } from '../../../domain/utilFunc';
-import { refiner, setDayPartition } from './position';
+import { getHeightRatio, refiner, setDayPartition, setPricePartition } from './position';
 
 /**
  * drawBasicCandleChart
@@ -21,11 +21,15 @@ export const drawBasicCandleChart = ({
 }: DrawCandleChartOptions): object => {
   const { zeroX, zeroY, ratio, canvasWidth, canvasHeight } = initCanvas(ctx);
 
+  const { ratioH, lowest, highest } = getHeightRatio(results, zeroY);
+
   /** 캔버스 그리기 쉽게 데이터 전처리 */
   const { data, candleWidth, numToShow } = refiner(results, {
     zeroX,
     zeroY,
     count,
+    ratioH,
+    lowest,
     range: range(0, count),
     customNumToShow,
   });
@@ -39,6 +43,9 @@ export const drawBasicCandleChart = ({
   for (const { duration, color, width } of smaConfigs) {
     setSMA(ctx, data, { duration, color, width });
   }
+
+  /** 가격 구분선 */
+  setPricePartition(ctx, { highest, lowest, zeroY, ratioH, canvasWidth, canvasHeight });
 
   /** 일자구분선 */
   setDayPartition(ctx, { data, results, numToShow, count, canvasWidth, canvasHeight, zeroY });

--- a/packages/wiii/frontend/utils/chart/drawers.ts
+++ b/packages/wiii/frontend/utils/chart/drawers.ts
@@ -11,8 +11,8 @@ export const drawText = (
 ) => {
   ctx.save();
   ctx.strokeStyle = CandleColorEnum.grey900;
-  ctx.font = `${fontSize ?? canvasHeight * 0.014}px ${fontFamily ?? `sans-serif`}`;
   ctx.textBaseline = textBaseline ?? 'bottom';
+  ctx.font = `${fontSize ?? `25px/30`}px ${fontFamily ?? `sans-serif`}`;
   ctx.textAlign = textAlign ?? 'right';
   ctx.fillText(text, centerX, centerY);
   ctx.strokeText(text, centerX, centerY);

--- a/packages/wiii/frontend/utils/chart/drawers.ts
+++ b/packages/wiii/frontend/utils/chart/drawers.ts
@@ -1,5 +1,9 @@
 import { CandleColorEnum, DrawLineOptions, DrawLinePaths, DrawTextOptions, DrawTextRequired, RefinedCandle } from '@/type/chart';
-import { CandleOne } from '../../../domain/marketData';
+import { sunnyYellow, grey900 } from '@/styles/index.scss';
+
+/** @todo Vuex에서 is다크모드 getter로 가져오기  */
+const isDark = true;
+const baseFontStyle = isDark ? `${sunnyYellow}` : `${grey900}`;
 
 /** @description ctx.rotate() 사용시 필요 */
 const { PI } = Math;
@@ -11,7 +15,8 @@ export const drawText = (
   { fontFamily, fontSize, textBaseline, textAlign, /** @todo 쓰기 애매해서 뺄수도 */ textWidth }: DrawTextOptions,
 ) => {
   ctx.save();
-  ctx.strokeStyle = CandleColorEnum.grey900;
+  ctx.strokeStyle = baseFontStyle;
+  ctx.fillStyle = baseFontStyle;
   ctx.textBaseline = textBaseline ?? 'bottom';
   ctx.font = `${fontSize ?? `25px/30`}px ${fontFamily ?? `sans-serif`}`;
   ctx.textAlign = textAlign ?? 'right';

--- a/packages/wiii/frontend/utils/chart/drawers.ts
+++ b/packages/wiii/frontend/utils/chart/drawers.ts
@@ -1,4 +1,5 @@
 import { CandleColorEnum, DrawLineOptions, DrawLinePaths, DrawTextOptions, DrawTextRequired, RefinedCandle } from '@/type/chart';
+import { CandleOne } from '../../../domain/marketData';
 
 /** @description ctx.rotate() 사용시 필요 */
 const { PI } = Math;
@@ -6,7 +7,7 @@ const BASE_RADIAN = PI / 180;
 
 export const drawText = (
   ctx: CanvasRenderingContext2D,
-  { text, centerX, centerY, canvasHeight }: DrawTextRequired,
+  { text, centerX, centerY, ratio }: DrawTextRequired,
   { fontFamily, fontSize, textBaseline, textAlign, /** @todo 쓰기 애매해서 뺄수도 */ textWidth }: DrawTextOptions,
 ) => {
   ctx.save();
@@ -16,13 +17,14 @@ export const drawText = (
   ctx.textAlign = textAlign ?? 'right';
   ctx.fillText(text, centerX, centerY);
   ctx.strokeText(text, centerX, centerY);
+  ctx.scale(ratio, ratio);
   ctx.restore();
 };
 
 export const drawLine = (
   ctx: CanvasRenderingContext2D,
   { beginX, beginY, lastX, lastY }: DrawLinePaths,
-  { color, lineWidth }: DrawLineOptions,
+  { ratio, color, lineWidth }: DrawLineOptions,
 ) => {
   ctx.save();
   ctx.strokeStyle = color || CandleColorEnum.grey900;
@@ -32,6 +34,7 @@ export const drawLine = (
   ctx.lineTo(lastX, lastY);
   ctx.closePath();
   ctx.stroke();
+  ctx.scale(ratio, ratio);
   ctx.restore();
 };
 
@@ -45,16 +48,25 @@ export const drawCandle = (
   ctx.save();
 
   /** 캔들 꼬리 */
-  drawLine(ctx, { beginX: centerX, beginY: highY, lastX: centerX, lastY: lowY }, { color });
+  drawLine(ctx, { beginX: centerX, beginY: highY, lastX: centerX, lastY: lowY }, { ratio, color });
 
   /** 캔들 몸통 */
   if (rectH === 0) {
-    drawLine(ctx, { beginX: startX, beginY: openY, lastX: startX + candleWidth, lastY: openY }, {});
+    drawLine(ctx, { beginX: startX, beginY: openY, lastX: startX + candleWidth, lastY: openY }, { ratio });
   } else {
     ctx.fillStyle = color;
     ctx.fillRect(startX, openY, candleWidth, rectH);
   }
 
   ctx.scale(ratio, ratio);
+  ctx.restore();
+};
+
+export const drawVolume = (ctx: CanvasRenderingContext2D, { startX, volume, base, candleWidth, ratio, color }) => {
+  ctx.save();
+  ctx.fillStyle = color;
+  const height = volume * ratio;
+  ctx.fillRect(startX, base - height, candleWidth, height);
+
   ctx.restore();
 };

--- a/packages/wiii/frontend/utils/chart/init.ts
+++ b/packages/wiii/frontend/utils/chart/init.ts
@@ -32,7 +32,7 @@ export const initCanvas = (ctx: CanvasRenderingContext2D): ClientWH => {
 
   /** @todo 좀 이해안가는 부분.. */
   const zeroX = canvasWidth * 0.927;
-  const zeroY = zeroX * 1.1;
+  const zeroY = zeroX * 1.12;
 
   return {
     /** 영점 */

--- a/packages/wiii/frontend/utils/chart/sma.ts
+++ b/packages/wiii/frontend/utils/chart/sma.ts
@@ -21,7 +21,7 @@ const getAvg = (data: RefinedCandle[], start: number, duration: number) =>
 /**
  * setSMA(ctx, data, {duration, color})
  */
-export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { duration, color, width }: SMAOptions) => {
+export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { ratio, duration, color, width }: SMAOptions) => {
   /** 가장 오래된 기간은 제외 */
   const length = data.length - duration;
   if (duration > length) return;
@@ -34,7 +34,7 @@ export const setSMA = (ctx: CanvasRenderingContext2D, data: RefinedCandle[], { d
     const { centerX: prevX } = data[i + 1];
     const prevAvg = getAvg(data, i, duration);
 
-    drawLine(ctx, { beginX: curX, beginY: curAvg, lastX: prevX, lastY: prevAvg }, { color, lineWidth: width });
+    drawLine(ctx, { beginX: curX, beginY: curAvg, lastX: prevX, lastY: prevAvg }, { ratio, color, lineWidth: width });
 
     curAvg = prevAvg;
   }


### PR DESCRIPTION
## Feat: 컴포넌트 전반 다크모드 적용, 다크모드 전용 색상 추가

![image](https://user-images.githubusercontent.com/57997672/120464470-ed352480-c3d7-11eb-8b4a-a520990ca710.png)


- 네온 느낌 다크 테마
  - 차트 폰트 색상에도 적용
  - color palette :  https://colorswall.com/palette/94171/ 참고

## TODO

- Vuex에서 다크테마 토글 관리