### PR TITLE
Add common MarketService

### DIFF
--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -1,0 +1,89 @@
+import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import * as yahooFinance from 'yahoo-finance';
+import { marketStackConfig } from '../config';
+import { MarketSymbol, SummaryDetail, EndOfDay, tickerMap, MarketStockEOD, HistoricalData } from '../../domain';
+import axios, { AxiosInstance } from 'axios';
+
+@Service()
+export default class MarketService {
+  private readonly baseUrl = 'http://api.marketstack.com/v1';
+  private readonly axiosClient: AxiosInstance;
+
+  constructor() {
+    this.axiosClient = axios.create({
+      baseURL: this.baseUrl,
+      params: { access_key: marketStackConfig.accessKey },
+    });
+  }
+
+  private convertSymbolsToQueryString(symbols: MarketSymbol[]) {
+    return symbols.join(',');
+  }
+
+  private getDisplayName(symbol: MarketSymbol): string {
+    const { stock, crypto, index } = tickerMap;
+
+    if (stock[symbol]?.name) return stock[symbol].name;
+    if (crypto[symbol]?.name) return crypto[symbol].name;
+    if (index[symbol]?.name) return index[symbol].name;
+
+    throw new Error('invalid symbol');
+  }
+
+  private addDisplayName(eod: MarketStockEOD): EndOfDay {
+    const displayName = this.getDisplayName(eod.symbol);
+    return { ...eod, display_name: displayName };
+  }
+
+  /**
+   * getLatestEOD
+   *
+   * 여러 종목의 가장 최근 end-of-day 데이터를 반환한다
+   *
+   * @author dogyeong
+   * @param {MarketSymbol[]} symbols ticker 심볼 배열
+   */
+  public async getLatestEOD(symbols: MarketSymbol[]): Promise<EndOfDay[]> {
+    const symbolQueryStr = this.convertSymbolsToQueryString(symbols);
+    const { data: response } = await this.axiosClient.get('/eod/latest', {
+      params: { symbols: symbolQueryStr },
+    });
+
+    return response?.data?.map(this.addDisplayName.bind(this)) ?? [];
+  }
+
+  /**
+   * getSummaryDetail
+   *
+   * 한 종목의 개요 정보를 반환한다
+   *
+   * @author dogyeong
+   * @param {MarketSymbol} symbol ticker 심볼
+   */
+  public async getSummaryDetail(symbol: MarketSymbol): Promise<SummaryDetail> {
+    const { summaryDetail } = await yahooFinance.quote({
+      symbol,
+      modules: ['summaryDetail'],
+    });
+
+    return summaryDetail;
+  }
+
+  /**
+   * getHistoricalData
+   *
+   * 한 종목의 HistoricalData를 반환한다
+   *
+   * @author dogyeong
+   * @param {MarketSymbol} symbol ticker 심볼
+   */
+  public async getHistoricalData(symbol: MarketSymbol): Promise<HistoricalData> {
+    const { data: response } = await this.axiosClient.get(`/tickers/${symbol}/eod`);
+    const displayName = this.getDisplayName(symbol);
+
+    return {
+      display_name: displayName,
+      data: response?.data?.eod ?? [],
+    };
+  }
+}

--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -30,9 +30,13 @@ export default class MarketService {
     throw new Error('invalid symbol');
   }
 
-  private addDisplayName(eod: MarketStockEOD): EndOfDay {
+  private convertEOD(eod: MarketStockEOD): EndOfDay {
     const displayName = this.getDisplayName(eod.symbol);
-    return { ...eod, display_name: displayName };
+    const wasChanged = !Number.isNaN(eod.close - eod.open);
+    const diff = wasChanged ? +(eod.close - eod.open).toFixed(2) : 0;
+    const growthRate = wasChanged ? +(diff / eod.close).toFixed(2) : 0;
+
+    return { ...eod, display_name: displayName, diff, growthRate };
   }
 
   /**
@@ -49,7 +53,7 @@ export default class MarketService {
       params: { symbols: symbolQueryStr },
     });
 
-    return response?.data?.map(this.addDisplayName.bind(this)) ?? [];
+    return response?.data?.map(this.convertEOD) ?? [];
   }
 
   /**

--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -53,7 +53,7 @@ export default class MarketService {
       params: { symbols: symbolQueryStr },
     });
 
-    return response?.data?.map(this.convertEOD) ?? [];
+    return response?.data?.map(this.convertEOD.bind(this)) ?? [];
   }
 
   /**

--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -34,7 +34,7 @@ export default class MarketService {
     const displayName = this.getDisplayName(eod.symbol);
     const wasChanged = !Number.isNaN(eod.close - eod.open);
     const diff = wasChanged ? +(eod.close - eod.open).toFixed(2) : 0;
-    const growthRate = wasChanged ? +(diff / eod.close).toFixed(2) : 0;
+    const growthRate = wasChanged ? +((diff / eod.open) * 100).toFixed(2) : 0;
 
     return { ...eod, display_name: displayName, diff, growthRate };
   }

--- a/packages/common/domain/index.ts
+++ b/packages/common/domain/index.ts
@@ -113,6 +113,8 @@ export interface MarketStockEOD {
 
 export interface EndOfDay extends MarketStockEOD {
   display_name: string;
+  diff: number;
+  growthRate: number;
 }
 
 export interface HistoricalData {

--- a/packages/common/domain/index.ts
+++ b/packages/common/domain/index.ts
@@ -1,41 +1,121 @@
-// 지수, 주식, 가상화폐
+// 지수, 주식, 가상화폐 tickers
 export const tickerMap = {
   index: {
-    IXIC: {
-      investing: 'indices/nq-100',
+    // 실제 api에서 사용되는 ticker
+    FB: {
+      //  화면에 표시될 종목 이름
       name: '나스닥100',
     },
-    DJI: {
-      investing: 'indices/us-30',
+    ADBE: {
       name: '다우존스30',
     },
-    SPX: {
-      investing: 'indices/us-spx-500',
+    ADI: {
       name: 'S&P500',
+    },
+    ADP: {
+      name: 'foo index',
+    },
+    ADSK: {
+      name: 'bar index',
     },
   },
   crypto: {
-    BTC: {
-      investing: 'crypto/bitcoin/btc-usd',
+    BIDU: {
       name: '비트코인',
     },
-    ETH: {
-      investing: 'crypto/ethereum/eth-usd?c997650',
+    EBAY: {
       name: '이더리움',
+    },
+    INTC: {
+      name: 'foo coin',
+    },
+    MAR: {
+      name: 'bar coin',
+    },
+    MNST: {
+      name: 'baz coin',
     },
   },
   stock: {
-    APPL: {
-      investing: 'equities/apple-computer-inc',
+    AAPL: {
       name: '애플',
     },
     GOOG: {
-      investing: 'equities/google-inc',
       name: '구글',
     },
     TSLA: {
-      investing: 'equities/tesla-motors',
       name: '테슬라',
+    },
+    AMZN: {
+      name: '아마존',
+    },
+    PYPL: {
+      name: '페이팔',
     },
   },
 } as const;
+
+export type IndexSymbol = keyof typeof tickerMap.index;
+
+export type CryptoSymbol = keyof typeof tickerMap.crypto;
+
+export type StockSymbol = keyof typeof tickerMap.stock;
+
+export type MarketSymbol = IndexSymbol | CryptoSymbol | StockSymbol;
+
+// 종목상세 : 52주 변동폭, 일일 변동폭, 거래량(volume), 시가총액(marketcap), 매수가(bid), 매도가(ask),
+export interface SummaryDetail {
+  maxAge: number;
+  priceHint: number;
+  previousClose: number;
+  open: number;
+  dayLow: number;
+  dayHigh: number;
+  regularMarketPreviousClose: number;
+  regularMarketOpen: number;
+  regularMarketDayLow: number;
+  regularMarketDayHigh: number;
+  dividendRate: number;
+  dividendYield: number;
+  exDividendDate: Date;
+  payoutRatio: number;
+  fiveYearAvgDividendYield: number;
+  beta: number;
+  trailingPE: number;
+  forwardPE: number;
+  volume: number;
+  regularMarketVolume: number;
+  averageVolume: number;
+  averageVolume10days: number;
+  averageDailyVolume10Day: number;
+  bid: number;
+  ask: number;
+  bidSize: number;
+  askSize: number;
+  marketCap: number;
+  fiftyTwoWeekLow: number;
+  fiftyTwoWeekHigh: number;
+  priceToSalesTrailing12Months: number;
+  fiftyDayAverage: number;
+  twoHundredDayAverage: number;
+  trailingAnnualDividendRate: number;
+  trailingAnnualDividendYield: number;
+}
+
+export interface MarketStockEOD {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  symbol: MarketSymbol;
+}
+
+export interface EndOfDay extends MarketStockEOD {
+  display_name: string;
+}
+
+export interface HistoricalData {
+  display_name: string;
+  data: MarketStockEOD[];
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,7 @@
     "mongoose": "^5.12.12",
     "typescript": "^4.2.4",
     "vue": "^2.6.12",
-    "zum-portal-core": "1.1.1"
+    "zum-portal-core": "1.1.1",
+    "yahoo-finance": "https://github.com/dogyeong/node-yahoo-finance"
   }
 }


### PR DESCRIPTION
## 작업내용 

- 시장 탭에서 사용할 api를 위한 서비스 구현
  - 지수, 주식, 가상화폐 리스트의 가격, 변동률 데이터
  - 상세페이지에서 보이는 개요 데이터
  - 그래프 데이터
- 사용할 ticker 리스트 추가
  - common/domain에 위치

## Example

tickerMap에 있는 지수들의 데이터 받아오기 (현재가격?)
```ts
const indexSymbols = Object.keys(tickerMap.index) as IndexSymbol[];
const indices = await this.marketService.getLatestEOD(indexSymbols);
```

개요 데이터 받아오기
```ts
const { symbol } = req.params;
const summary = await this.marketService.getSummaryDetail(symbol as MarketSymbol);
```

그래프 데이터 받아오기
```ts
const { symbol } = req.params;
const chart = await this.marketService.getHistoricalData(symbol as MarketSymbol);
```