### PR TITLE
Fix article service

### DIFF
--- a/packages/common/backend/service/ArticleService.ts
+++ b/packages/common/backend/service/ArticleService.ts
@@ -2,6 +2,7 @@ import { isValidObjectId, ObjectId } from 'mongoose';
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import { Caching } from 'zum-portal-core/backend/decorator/Caching';
 import Article, { ArticleType, ArticleDoc } from '../model/ArticleModel';
+import * as NodeCache from 'node-cache';
 
 interface QueryProps {
   offset?: number;
@@ -9,13 +10,15 @@ interface QueryProps {
   tickers?: string[];
 }
 
+const cache = new NodeCache({ deleteOnExpire: true });
+
 @Service()
 export default class ArticleService {
   private getTickerOption(tickers?: string[]) {
     return tickers ? { tickers: { $in: tickers } } : {};
   }
 
-  @Caching({ ttl: 10, runOnStart: false })
+  @Caching({ ttl: 30, runOnStart: false, cache })
   public async getNews({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
     const tickerOption = this.getTickerOption(tickers);
     const query = { type: ArticleType.news, ...tickerOption };
@@ -27,7 +30,7 @@ export default class ArticleService {
       .lean<ArticleDoc[]>();
   }
 
-  @Caching({ ttl: 10, runOnStart: false })
+  @Caching({ ttl: 30, runOnStart: false, cache })
   public async getOpinions({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
     const tickerOption = this.getTickerOption(tickers);
     const query = { type: ArticleType.opinions, ...tickerOption };
@@ -39,7 +42,7 @@ export default class ArticleService {
       .lean<ArticleDoc[]>();
   }
 
-  @Caching({ ttl: 10, runOnStart: false })
+  @Caching({ ttl: 30, runOnStart: false, cache })
   public async getArticleById(id: ObjectId | string): Promise<ArticleDoc> {
     if (!isValidObjectId(id)) throw new Error('invalid id');
 

--- a/packages/common/backend/service/ArticleService.ts
+++ b/packages/common/backend/service/ArticleService.ts
@@ -4,12 +4,6 @@ import { Caching } from 'zum-portal-core/backend/decorator/Caching';
 import Article, { ArticleType, ArticleDoc } from '../model/ArticleModel';
 import * as NodeCache from 'node-cache';
 
-interface QueryProps {
-  offset?: number;
-  limit?: number;
-  tickers?: string[];
-}
-
 const cache = new NodeCache({ deleteOnExpire: true });
 
 @Service()
@@ -19,7 +13,7 @@ export default class ArticleService {
   }
 
   @Caching({ ttl: 30, runOnStart: false, cache })
-  public async getNews({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
+  public async getNews(offset = 0, limit = 10, tickers?: string[]): Promise<ArticleDoc[]> {
     const tickerOption = this.getTickerOption(tickers);
     const query = { type: ArticleType.news, ...tickerOption };
 
@@ -31,7 +25,7 @@ export default class ArticleService {
   }
 
   @Caching({ ttl: 30, runOnStart: false, cache })
-  public async getOpinions({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
+  public async getOpinions(offset = 0, limit = 10, tickers?: string[]): Promise<ArticleDoc[]> {
     const tickerOption = this.getTickerOption(tickers);
     const query = { type: ArticleType.opinions, ...tickerOption };
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,9 +14,10 @@
     "@vue/cli-plugin-typescript": "^4.5.13",
     "cross-env": "^7.0.3",
     "mongoose": "^5.12.12",
+    "node-cache": "^5.1.2",
     "typescript": "^4.2.4",
     "vue": "^2.6.12",
-    "zum-portal-core": "1.1.1",
-    "yahoo-finance": "https://github.com/dogyeong/node-yahoo-finance"
+    "yahoo-finance": "https://github.com/dogyeong/node-yahoo-finance",
+    "zum-portal-core": "1.1.1"
   }
 }

--- a/packages/dogyeong/src/backend/controller/ArticleController.ts
+++ b/packages/dogyeong/src/backend/controller/ArticleController.ts
@@ -16,11 +16,7 @@ export class ApiController {
   public async getNewNews(req: Request, res: Response) {
     try {
       const { offset, limit, tickers } = req.query;
-      const news = await this.articleService.getNews({
-        offset: +offset,
-        limit: +limit,
-        tickers: this.getTickerArray(tickers),
-      });
+      const news = await this.articleService.getNews(+offset, +limit, this.getTickerArray(tickers));
       res.json(news);
     } catch (err) {
       res.status(500).json({ err: err.message ?? err });
@@ -31,11 +27,7 @@ export class ApiController {
   public async getNewOpinions(req: Request, res: Response) {
     try {
       const { offset, limit, tickers } = req.query;
-      const news = await this.articleService.getOpinions({
-        offset: +offset,
-        limit: +limit,
-        tickers: this.getTickerArray(tickers),
-      });
+      const news = await this.articleService.getOpinions(+offset, +limit, this.getTickerArray(tickers));
       res.json(news);
     } catch (err) {
       res.status(500).json({ err: err.message ?? err });
@@ -46,11 +38,7 @@ export class ApiController {
   public async getPopularNews(req: Request, res: Response) {
     try {
       const { offset, limit, tickers } = req.query;
-      const news = await this.articleService.getNews({
-        offset: +offset,
-        limit: +limit,
-        tickers: this.getTickerArray(tickers),
-      });
+      const news = await this.articleService.getNews(+offset, +limit, this.getTickerArray(tickers));
       res.json(news);
     } catch (err) {
       res.status(500).json({ err: err.message ?? err });
@@ -61,11 +49,7 @@ export class ApiController {
   public async getPopularOpinions(req: Request, res: Response) {
     try {
       const { offset, limit, tickers } = req.query;
-      const news = await this.articleService.getOpinions({
-        offset: +offset,
-        limit: +limit,
-        tickers: this.getTickerArray(tickers),
-      });
+      const news = await this.articleService.getOpinions(+offset, +limit, this.getTickerArray(tickers));
       res.json(news);
     } catch (err) {
       res.status(500).json({ err: err.message ?? err });


### PR DESCRIPTION
## 작업내용

- 뉴스 관련 ArticleService 에서 캐싱 이슈 해결
  - 캐시가 시간이 지나도 삭제되지 않는 이슈
    - cache 객체를 옵션으로 넘기지 않으면 기본 캐시가 사용되고, 기본 캐시는 삭제되지 않도록 되어있음
    - 그래서 NodeCache 인스턴스를 생성하여 옵션으로 전달하여 해결
  - 서로 다른 파라미터를 가지는 요청에 대해 같은 캐시가 사용되는 이슈
    - 메소드 파라미터를 객체로 넘기면 캐시 키가 객체값에 상관없이 똑같이 지정되는 것이 원인
    - 메소드 파라미터를  객체가 아니라 풀어서 전달하도록 하여 해결