### PR TITLE
Add chart period option

### DIFF
--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -1,4 +1,5 @@
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
+import { Caching } from 'zum-portal-core/backend/decorator/Caching';
 import * as yahooFinance from 'yahoo-finance';
 import { marketStackConfig } from '../config';
 import {
@@ -12,11 +13,9 @@ import {
   ChartPeriod,
 } from '../../domain';
 import axios, { AxiosInstance } from 'axios';
+import * as NodeCache from 'node-cache';
 
-interface GetHistoricalDataProps {
-  symbol: MarketSymbol;
-  period: ChartPeriod;
-}
+const cache = new NodeCache({ deleteOnExpire: true });
 
 @Service()
 export default class MarketService {
@@ -76,6 +75,7 @@ export default class MarketService {
    * @author dogyeong
    * @param {MarketSymbol[]} symbols ticker 심볼 배열
    */
+  @Caching({ ttl: 30, cache, runOnStart: false })
   public async getLatestEOD(symbols: MarketSymbol[]): Promise<EndOfDay[]> {
     if (!symbols.every(this.isValidSymbol.bind(this))) throw new Error('invalid symbol');
 
@@ -95,6 +95,7 @@ export default class MarketService {
    * @author dogyeong
    * @param {MarketSymbol} symbol ticker 심볼
    */
+  @Caching({ ttl: 30, cache, runOnStart: false })
   public async getSummaryDetail(symbol: MarketSymbol): Promise<SummaryDetail> {
     if (!this.isValidSymbol(symbol)) throw new Error('invalid symbol');
 
@@ -114,7 +115,8 @@ export default class MarketService {
    * @author dogyeong
    * @param {MarketSymbol} symbol ticker 심볼
    */
-  public async getHistoricalData({ symbol, period }: GetHistoricalDataProps): Promise<HistoricalData> {
+  @Caching({ ttl: 30, cache, runOnStart: false })
+  public async getHistoricalData(symbol: MarketSymbol, period: ChartPeriod): Promise<HistoricalData> {
     if (!this.isValidSymbol(symbol)) throw new Error('invalid symbol');
     if (!this.isValidPeriod(period)) throw new Error('invalid period');
 

--- a/packages/common/backend/service/MarketService.ts
+++ b/packages/common/backend/service/MarketService.ts
@@ -1,8 +1,22 @@
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import * as yahooFinance from 'yahoo-finance';
 import { marketStackConfig } from '../config';
-import { MarketSymbol, SummaryDetail, EndOfDay, tickerMap, MarketStockEOD, HistoricalData } from '../../domain';
+import {
+  MarketSymbol,
+  SummaryDetail,
+  EndOfDay,
+  tickerMap,
+  MarketStockEOD,
+  HistoricalData,
+  IntraDayChartMap,
+  ChartPeriod,
+} from '../../domain';
 import axios, { AxiosInstance } from 'axios';
+
+interface GetHistoricalDataProps {
+  symbol: MarketSymbol;
+  period: ChartPeriod;
+}
 
 @Service()
 export default class MarketService {
@@ -14,6 +28,16 @@ export default class MarketService {
       baseURL: this.baseUrl,
       params: { access_key: marketStackConfig.accessKey },
     });
+  }
+
+  private isValidSymbol(symbol: string) {
+    return Object.keys(tickerMap).some((type: keyof typeof tickerMap) => {
+      return Object.prototype.hasOwnProperty.call(tickerMap[type], symbol);
+    });
+  }
+
+  private isValidPeriod(period: string) {
+    return Object.prototype.hasOwnProperty.call(IntraDayChartMap, period);
   }
 
   private convertSymbolsToQueryString(symbols: MarketSymbol[]) {
@@ -39,6 +63,11 @@ export default class MarketService {
     return { ...eod, display_name: displayName, diff, growthRate };
   }
 
+  private getIntraDayOptions(period: ChartPeriod) {
+    const { interval, dateFrom, dateTo } = IntraDayChartMap[period];
+    return { interval, date_from: dateFrom(), date_to: dateTo() };
+  }
+
   /**
    * getLatestEOD
    *
@@ -48,6 +77,8 @@ export default class MarketService {
    * @param {MarketSymbol[]} symbols ticker 심볼 배열
    */
   public async getLatestEOD(symbols: MarketSymbol[]): Promise<EndOfDay[]> {
+    if (!symbols.every(this.isValidSymbol.bind(this))) throw new Error('invalid symbol');
+
     const symbolQueryStr = this.convertSymbolsToQueryString(symbols);
     const { data: response } = await this.axiosClient.get('/eod/latest', {
       params: { symbols: symbolQueryStr },
@@ -65,6 +96,8 @@ export default class MarketService {
    * @param {MarketSymbol} symbol ticker 심볼
    */
   public async getSummaryDetail(symbol: MarketSymbol): Promise<SummaryDetail> {
+    if (!this.isValidSymbol(symbol)) throw new Error('invalid symbol');
+
     const { summaryDetail } = await yahooFinance.quote({
       symbol,
       modules: ['summaryDetail'],
@@ -81,13 +114,18 @@ export default class MarketService {
    * @author dogyeong
    * @param {MarketSymbol} symbol ticker 심볼
    */
-  public async getHistoricalData(symbol: MarketSymbol): Promise<HistoricalData> {
-    const { data: response } = await this.axiosClient.get(`/tickers/${symbol}/eod`);
+  public async getHistoricalData({ symbol, period }: GetHistoricalDataProps): Promise<HistoricalData> {
+    if (!this.isValidSymbol(symbol)) throw new Error('invalid symbol');
+    if (!this.isValidPeriod(period)) throw new Error('invalid period');
+
+    const { data: response } = await this.axiosClient.get(`/tickers/${symbol}/intraday`, {
+      params: this.getIntraDayOptions(period),
+    });
     const displayName = this.getDisplayName(symbol);
 
     return {
       display_name: displayName,
-      data: response?.data?.eod ?? [],
+      data: response?.data?.intraday ?? [],
     };
   }
 }

--- a/packages/common/domain/index.ts
+++ b/packages/common/domain/index.ts
@@ -122,6 +122,66 @@ export interface HistoricalData {
   data: MarketStockEOD[];
 }
 
+/**
+ * 1d -> 5m
+ * 1w -> 30m
+ * 1m -> 1h
+ * 6m -> 3h
+ * 1y -> 12h
+ * 5y -> 24h
+ * max -> 24h
+ */
+const getPastDate = ({ day = 0, month = 0, year = 0 } = {}) => {
+  const date = new Date();
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  const d = date.getDate();
+  date.setFullYear(y - year);
+  date.setMonth(m - month);
+  date.setDate(d - day);
+
+  return date;
+};
+
+const formatDate = (date: Date) => {
+  return date.toISOString().replace(/\..*/, '+0000');
+};
+
+export const IntraDayChartMap = {
+  '1d': {
+    interval: '5min',
+    dateFrom: () => formatDate(getPastDate({ day: 1 })),
+    dateTo: () => formatDate(new Date()),
+  },
+  '1w': {
+    interval: '30min',
+    dateFrom: () => formatDate(getPastDate({ day: 7 })),
+    dateTo: () => formatDate(new Date()),
+  },
+  '1m': {
+    interval: '1hour',
+    dateFrom: () => formatDate(getPastDate({ month: 1 })),
+    dateTo: () => formatDate(new Date()),
+  },
+  '1y': {
+    interval: '12hour',
+    dateFrom: () => formatDate(getPastDate({ year: 1 })),
+    dateTo: () => formatDate(new Date()),
+  },
+  '5y': {
+    interval: '24hour',
+    dateFrom: () => formatDate(getPastDate({ year: 1 })),
+    dateTo: () => formatDate(new Date()),
+  },
+  max: {
+    interval: '24hour',
+    dateFrom: () => formatDate(getPastDate({ year: 1000 })),
+    dateTo: () => formatDate(new Date()),
+  },
+} as const;
+
+export type ChartPeriod = keyof typeof IntraDayChartMap;
+
 // 캐시 관련
 const secondUnit = 1000;
 const hourUnit = 60 * 60 * secondUnit;

--- a/packages/dogyeong/src/backend/controller/MarketController.ts
+++ b/packages/dogyeong/src/backend/controller/MarketController.ts
@@ -2,7 +2,7 @@ import { Controller, GetMapping } from 'zum-portal-core/backend/decorator/Contro
 import { Request, Response } from 'express';
 import { Inject } from 'zum-portal-core/backend/decorator/Alias';
 import MarketService from 'common/backend/service/MarketService';
-import { tickerMap, StockSymbol, IndexSymbol, CryptoSymbol, MarketSymbol } from 'common/domain';
+import { tickerMap, StockSymbol, IndexSymbol, CryptoSymbol, MarketSymbol, ChartPeriod } from 'common/domain';
 
 @Controller({ path: '/api/market' })
 export class MarketController {
@@ -56,7 +56,8 @@ export class MarketController {
   public async getChart(req: Request, res: Response) {
     try {
       const { symbol } = req.params;
-      const chart = await this.marketService.getHistoricalData(symbol as MarketSymbol);
+      const { period } = req.query;
+      const chart = await this.marketService.getHistoricalData(symbol as MarketSymbol, period as ChartPeriod);
       res.json(chart);
     } catch (err) {
       res.status(500).json({ err: err.message ?? err });

--- a/packages/dogyeong/src/frontend/services/financeService.ts
+++ b/packages/dogyeong/src/frontend/services/financeService.ts
@@ -1,8 +1,13 @@
 import { AxiosStatic } from 'axios';
 import { apiEndpoints } from '@/config';
-import { MarketSymbol, EndOfDay, SummaryDetail, HistoricalData } from 'common/domain';
+import { MarketSymbol, EndOfDay, SummaryDetail, HistoricalData, ChartPeriod } from 'common/domain';
 
 declare const Axios: AxiosStatic;
+
+interface GetChartProps {
+  symbol: MarketSymbol;
+  period: ChartPeriod;
+}
 
 export const getIndices = async (): Promise<EndOfDay[]> => {
   const { data } = await Axios.get(apiEndpoints.getIndices);
@@ -24,7 +29,7 @@ export const getSummary = async (symbol: MarketSymbol): Promise<SummaryDetail> =
   return data;
 };
 
-export const getChart = async (symbol: MarketSymbol): Promise<HistoricalData> => {
-  const { data } = await Axios.get(`${apiEndpoints.getChart}/${symbol}`);
+export const getChart = async ({ symbol, period = '1d' }: GetChartProps): Promise<HistoricalData> => {
+  const { data } = await Axios.get(`${apiEndpoints.getChart}/${symbol}`, { params: { period } });
   return data;
 };

--- a/packages/dogyeong/tsconfig.frontend.json
+++ b/packages/dogyeong/tsconfig.frontend.json
@@ -10,7 +10,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "allowJs": true,
-    "lib": ["esnext"]
+    "lib": ["esnext", "DOM", "DOM.Iterable", "ScriptHost"]
   },
 
   "exclude": ["**/backend/**", "**/node_modules/**"]


### PR DESCRIPTION
## 작업내용

- `common/MarketService`에 기간별 차트를 받아올 수 있도록 수정
  - `common/domain`에 있는 `IntraDayChartMap`에 전달할 수 있는 값 정의
- `common/MarketService` 캐싱 적용
