### PR TITLE
[feature] 검색 페이지에 뉴스 및 분석 데이터 렌더링

### DIFF
--- a/packages/common/backend/service/ArticleService.ts
+++ b/packages/common/backend/service/ArticleService.ts
@@ -27,8 +27,30 @@ export default class ArticleService {
       .lean<ArticleDoc[]>();
   }
 
+  public async getNewsForSearch({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
+    const tickerOption = this.getTickerOption(tickers);
+    const query = { type: ArticleType.news, ...tickerOption };
+
+    return Article.find(query)
+      .sort({ date: 'desc' })
+      .skip(offset)
+      .limit(limit)
+      .lean<ArticleDoc[]>();
+  }
+
   @Caching({ ttl: 10, runOnStart: false })
   public async getOpinions({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
+    const tickerOption = this.getTickerOption(tickers);
+    const query = { type: ArticleType.opinions, ...tickerOption };
+
+    return Article.find(query)
+      .sort({ date: 'desc' })
+      .skip(offset)
+      .limit(limit)
+      .lean<ArticleDoc[]>();
+  }
+
+  public async getOpinionsForSearch({ offset = 0, limit = 10, tickers }: QueryProps = {}): Promise<ArticleDoc[]> {
     const tickerOption = this.getTickerOption(tickers);
     const query = { type: ArticleType.opinions, ...tickerOption };
 

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -17,6 +17,7 @@ export interface getItemDetailInfo {
 export interface getNewsAndAnalysesInfo {
   offset: number;
   limit: number;
+  tickers: String[];
 }
 
 export interface createBookmarkInfo {
@@ -55,15 +56,55 @@ const getSearchedItems = async ({ keyword, email }: getSearchedItemsInfo) => {
 };
 
 /**
+ * @description search page에 렌더링할 searched news를 가져오는 front-side API call 함수
+ * @param param0
+ * @returns
+ */
+const getSearchedNews = async ({ offset, limit, tickers }: getNewsAndAnalysesInfo) => {
+  try {
+    const result = await Axios.get(`${devURL}/api/search/news`, {
+      params: { offset, limit, tickers },
+    });
+
+    if (result.status === 200) {
+      const { data: news } = result;
+
+      return news;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+/**
+ * search page에 렌더링할 searched analyses를 가져오는 front-side API call 함수
+ * @param param0
+ * @returns
+ */
+const getSearchedAnalyses = async ({ offset, limit, tickers }: getNewsAndAnalysesInfo) => {
+  try {
+    const result = await Axios.get(`${devURL}/api/search/analyses`, {
+      params: { offset, limit, tickers },
+    });
+
+    if (result.status === 200) {
+      const { data: news } = result;
+
+      return news;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+/**
  * @description item detail page에 렌더링할 item detail를 가져오는 front-side API 호출 함수
  * @param param0
  * @returns Promise
  */
 const getItemDetail = async ({ symbols, email }: getItemDetailInfo) => {
   try {
-    console.log(email);
     const result = await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}&email=${email}`);
-    console.log(result);
 
     if (result.status === 200) {
       const { data: itemDetail } = result;
@@ -82,9 +123,11 @@ const getItemDetail = async ({ symbols, email }: getItemDetailInfo) => {
  * @param param0
  * @returns Promise
  */
-const getNews = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
+const getNews = async ({ offset, limit, tickers }: getNewsAndAnalysesInfo) => {
   try {
-    const result = await Axios.get(`${devURL}/api/articles/news?offset=${offset}&limit=${limit}`);
+    const result = await Axios.get(`${devURL}/api/articles/news`, {
+      params: { offset, limit, tickers },
+    });
 
     if (result.status === 200) {
       const { data: news } = result;
@@ -104,9 +147,11 @@ const getNews = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
  * @returns Promise
  */
 
-const getAnalyses = async ({ offset, limit }: getNewsAndAnalysesInfo) => {
+const getAnalyses = async ({ offset, limit, tickers }: getNewsAndAnalysesInfo) => {
   try {
-    const result = await Axios.get(`${devURL}/api/articles/analyses?offset=${offset}&limit=${limit}`);
+    const result = await Axios.get(`${devURL}/api/articles/analyses`, {
+      params: { offset, limit, tickers },
+    });
 
     if (result.status === 200) {
       const { data: analyses } = result;
@@ -184,4 +229,14 @@ const getBookmarks = async (email: string) => {
   }
 };
 
-export { getSearchedItems, getItemDetail, getNews, getAnalyses, createBookmark, getBookmarks, deleteBookmark };
+export {
+  getSearchedAnalyses,
+  getSearchedItems,
+  getItemDetail,
+  getNews,
+  getAnalyses,
+  createBookmark,
+  getBookmarks,
+  deleteBookmark,
+  getSearchedNews,
+};

--- a/packages/common/frontend/components/ListWrapper.vue
+++ b/packages/common/frontend/components/ListWrapper.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="item-detail-wrapper" :style="style">
+  <div class="list-wrapper" :style="style">
     <slot></slot>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'ItemDetailWrapper',
+  name: 'ListWrapper',
   props: {
     excludedHeight: {
       type: Number,
@@ -25,7 +25,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.item-detail-wrapper {
+.list-wrapper {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
@@ -34,7 +34,7 @@ export default {
   scrollbar-width: none; /* Firefox */
 }
 
-.item-detail-wrapper::-webkit-scrollbar {
+.list-wrapper::-webkit-scrollbar {
   display: none;
 }
 </style>

--- a/packages/common/frontend/components/MultipurposeHeader.vue
+++ b/packages/common/frontend/components/MultipurposeHeader.vue
@@ -28,7 +28,7 @@
 
     <template v-if="isSearch">
       <header-button isBackButton></header-button>
-      <search-input @search-input-value-change="requestSearchedItems" />
+      <search-input @search-input-value-change="$emit('search-input-value-change', $event)" />
     </template>
 
     <template v-if="isHome">
@@ -140,13 +140,16 @@ export default {
   },
 
   methods: {
-    ...mapActions('search', ['getSearchedItems']),
+    ...mapActions('search', ['getSearchedItems', 'getSearchedNews', 'getSearchedAnalyses']),
 
-    requestSearchedItems(event) {
+    requestSearch(event) {
       const keyword = event.target.value;
 
       if (keyword) {
+        const tickers = [keyword];
         this.getSearchedItems({ keyword, email: this.email });
+        this.getSearchedNews({ offset: 0, limit: 10, tickers });
+        this.getSearchedAnalyses({ offset: 0, limit: 10, tickers });
       }
     },
   },

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -46,9 +46,9 @@ const actions = {
     }
   },
 
-  async getNews({ commit }, { offset, limit }) {
+  async getNews({ commit }, { offset, limit, tickers }) {
     try {
-      const news = await getNews({ offset, limit });
+      const news = await getNews({ offset, limit, tickers });
 
       if (news) {
         commit('changeNews', news);
@@ -62,9 +62,9 @@ const actions = {
     }
   },
 
-  async getAnalyses({ commit }, { offset, limit }) {
+  async getAnalyses({ commit }, { offset, limit, tickers }) {
     try {
-      const analyses = await getAnalyses({ offset, limit });
+      const analyses = await getAnalyses({ offset, limit, tickers });
 
       if (analyses) {
         commit('changeAnalyses', analyses);

--- a/packages/common/frontend/store/modules/search.ts
+++ b/packages/common/frontend/store/modules/search.ts
@@ -1,11 +1,11 @@
-import { getSearchedItems } from '../../apis';
+import { getSearchedItems, getSearchedNews, getSearchedAnalyses } from '../../apis';
 
 // 초기 state 값 설정
 const state = () => ({
   searchedItems: [],
 
   searchedNews: [],
-  searchedAnalysis: [],
+  searchedAnalyses: [],
 });
 
 // getter 설정
@@ -19,12 +19,45 @@ const actions = {
       const items = await getSearchedItems({ keyword, email });
 
       if (items) {
-        commit('changeSearchedItems', items);
+        commit('setSearchedItems', items);
 
         return true;
       }
 
       throw new Error('Getting searched items was failed in search store');
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async getSearchedNews({ commit }, { offset, limit, tickers }) {
+    try {
+      const news = await getSearchedNews({ offset, limit, tickers });
+
+      if (news) {
+        console.log(news);
+        commit('setSearchedNews', news);
+
+        return true;
+      }
+
+      throw new Error('Getting news was failed in itemDetail store');
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async getSearchedAnalyses({ commit }, { offset, limit, tickers }) {
+    try {
+      const analyses = await getSearchedAnalyses({ offset, limit, tickers });
+
+      if (analyses) {
+        commit('setSearchedAnalyses', analyses);
+
+        return true;
+      }
+
+      throw new Error('Getting news was failed in itemDetail store');
     } catch (error) {
       console.log(error);
     }
@@ -37,14 +70,22 @@ const actions = {
 
 // mutatuons 설정
 const mutations = {
-  changeSearchedItems(state, items) {
+  setSearchedItems(state, items) {
     state.searchedItems = items;
+  },
+
+  setSearchedNews(state, news) {
+    state.searchedNews = news;
+  },
+
+  setSearchedAnalyses(state, analyses) {
+    state.searchedAnalyses = analyses;
   },
 
   clearSearchStore(state) {
     state.searchedItems = [];
     state.searchedNews = [];
-    state.searchedAnalysis = [];
+    state.searchedAnalyses = [];
   },
 };
 

--- a/packages/common/frontend/store/modules/search.ts
+++ b/packages/common/frontend/store/modules/search.ts
@@ -35,7 +35,6 @@ const actions = {
       const news = await getSearchedNews({ offset, limit, tickers });
 
       if (news) {
-        console.log(news);
         commit('setSearchedNews', news);
 
         return true;

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -4,7 +4,7 @@
     <item-detail-price-box :itemDetail="itemDetail"></item-detail-price-box>
     <custom-swiper :navigatorButtonNames="swiperNavigatorButtonNames">
       <swiper-slide>
-        <item-detail-wrapper :excludedHeight="210">
+        <list-wrapper :excludedHeight="210">
           <!-- 차트 컴포넌트 자리  -->
           <item-detail-overview-box :itemDetail="itemDetail"></item-detail-overview-box>
           <!-- 댓글 컴포넌트 자리 -->
@@ -30,10 +30,10 @@
               </news-list-item>
             </news-list>
           </sub-content-box>
-        </item-detail-wrapper>
+        </list-wrapper>
       </swiper-slide>
       <swiper-slide>
-        <item-detail-wrapper :excludedHeight="210">
+        <list-wrapper :excludedHeight="210">
           <news-list>
             <news-list-item v-for="element in news" :key="element.id" :to="''">
               <news-image :src="element.image_url" />
@@ -43,10 +43,10 @@
               </news-text-box>
             </news-list-item>
           </news-list>
-        </item-detail-wrapper>
+        </list-wrapper>
       </swiper-slide>
       <swiper-slide>
-        <item-detail-wrapper :excludedHeight="210">
+        <list-wrapper :excludedHeight="210">
           <news-list>
             <news-list-item v-for="element in analyses" :key="element.id" :to="''">
               <news-image :src="element.image_url" />
@@ -56,7 +56,7 @@
               </news-text-box>
             </news-list-item>
           </news-list>
-        </item-detail-wrapper>
+        </list-wrapper>
       </swiper-slide>
     </custom-swiper>
     <bottom-naviagtor :navigatorButtonNames="bottomNavigatorButtonNames"></bottom-naviagtor>
@@ -71,7 +71,7 @@ import { text } from '../constants';
 import BottomNaviagtor from '../components/BottomNaviagtor.vue';
 import MultipurposeHeader from '../components/MultipurposeHeader.vue';
 import ItemDetailPriceBox from '../components/ItemDetail/ItemDetailPriceBox.vue';
-import ItemDetailWrapper from '../components/ItemDetail/ItemDetailWrapper';
+import ListWrapper from '../components/ListWrapper.vue';
 import CustomSwiper from '../components/CustomSwiper.vue';
 import ItemDetailOverviewBox from '../components/ItemDetail/ItemDetailOverviewBox.vue';
 import SubContentBox from '../components/ItemDetail/SubContentBox.vue';
@@ -98,7 +98,7 @@ export default {
     NewsTextBox,
     NewsTextBoxTitle,
     NewsTextBoxDesc,
-    ItemDetailWrapper,
+    ListWrapper,
   },
 
   data() {
@@ -128,10 +128,11 @@ export default {
   created() {
     const { symbols } = this.$route.query;
     const email = this.userInfo.userEmail;
+    const tickers = [symbols];
 
     this.getItemDetail({ symbols, email });
-    this.getNews({ offset: 0, limit: 3 });
-    this.getAnalyses({ offset: 0, limit: 3 });
+    this.getNews({ offset: 0, limit: 20, tickers });
+    this.getAnalyses({ offset: 0, limit: 20, tickers });
   },
 };
 </script>

--- a/packages/common/frontend/views/Search.vue
+++ b/packages/common/frontend/views/Search.vue
@@ -1,15 +1,35 @@
 <template>
   <div class="search-page">
-    <multipurpose-header :userInfo="userInfo" isSearch></multipurpose-header>
+    <multipurpose-header :userInfo="userInfo" isSearch @search-input-value-change="requestSearch"></multipurpose-header>
     <custom-swiper :navigatorButtonNames="swiperNavigatorButtonNames">
       <swiper-slide>
         <item-card-list :items="searchedItems" :excludedHeight="100" :userInfo="userInfo" isSearch></item-card-list>
       </swiper-slide>
       <swiper-slide>
-        <item-card-list :items="searchedItems" :excludedHeight="100"></item-card-list>
+        <list-wrapper :excludedHeight="100">
+          <news-list>
+            <news-list-item v-for="element in searchedNews" :key="element.id" :to="''">
+              <news-image :src="element.image_url" />
+              <news-text-box>
+                <news-text-box-title>{{ element.title }}</news-text-box-title>
+                <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
+              </news-text-box>
+            </news-list-item>
+          </news-list>
+        </list-wrapper>
       </swiper-slide>
       <swiper-slide>
-        <item-card-list :items="searchedItems" :excludedHeight="100"></item-card-list>
+        <list-wrapper :excludedHeight="100">
+          <news-list>
+            <news-list-item v-for="element in searchedAnalyses" :key="element.id" :to="''">
+              <news-image :src="element.image_url" />
+              <news-text-box>
+                <news-text-box-title>{{ element.title }}</news-text-box-title>
+                <news-text-box-desc :author="element.source" :publishDate="element.date"></news-text-box-desc>
+              </news-text-box>
+            </news-list-item>
+          </news-list>
+        </list-wrapper>
       </swiper-slide>
     </custom-swiper>
   </div>
@@ -20,9 +40,16 @@ import { SwiperSlide } from 'vue-awesome-swiper';
 import { mapState, mapActions } from 'vuex';
 
 import MultipurposeHeader from '../components/MultipurposeHeader.vue';
+import ListWrapper from '../components/ListWrapper.vue';
 import CustomSwiper from '../components/CustomSwiper.vue';
 import ItemCard from '../components/ItemCard.vue';
 import ItemCardList from '../components/ItemCardList.vue';
+import NewsList from '../components/News/NewsList.vue';
+import NewsListItem from '../components/News/NewsListItem.vue';
+import NewsImage from '../components/News/NewsImage.vue';
+import NewsTextBox from '../components/News/NewsTextBox.vue';
+import NewsTextBoxTitle from '../components/News/NewsTextBoxTitle.vue';
+import NewsTextBoxDesc from '../components/News/NewsTextBoxDesc.vue';
 
 import { text } from '../../../common/frontend/constants';
 
@@ -35,12 +62,21 @@ export default {
     ItemCard,
     ItemCardList,
     SwiperSlide,
+    NewsList,
+    NewsListItem,
+    NewsImage,
+    NewsTextBox,
+    NewsTextBoxTitle,
+    NewsTextBoxDesc,
+    ListWrapper,
   },
 
   computed: {
     ...mapState({
       userInfo: (state) => state.user,
       searchedItems: (state) => state.search.searchedItems,
+      searchedNews: (state) => state.search.searchedNews,
+      searchedAnalyses: (state) => state.search.searchedAnalyses,
     }),
   },
 
@@ -51,7 +87,19 @@ export default {
   },
 
   methods: {
-    ...mapActions('search', ['clearSearchStore']),
+    ...mapActions('search', ['getSearchedItems', 'getSearchedNews', 'getSearchedAnalyses', 'clearSearchStore']),
+
+    requestSearch(event) {
+      const keyword = event.target.value;
+      const email = this.userInfo.userEmail;
+
+      if (keyword) {
+        const tickers = [keyword];
+        this.getSearchedItems({ keyword, email });
+        this.getSearchedNews({ offset: 0, limit: 10, tickers });
+        this.getSearchedAnalyses({ offset: 0, limit: 10, tickers });
+      }
+    },
   },
 
   beforeDestroy() {

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -265,15 +265,25 @@ export class ApiController {
     }
   }
 
+  /**
+   * @description DB에서 articles 중 검색된 news만 가져오는 controller
+   * @param request
+   * @param response
+   * @returns
+   */
   @GetMapping({ path: '/search/news' })
   public async getNewsForSearch(request: Request, response: Response) {
     try {
       const { offset, limit, tickers } = request.query;
+
+      console.log(tickers);
       const news = await this.articleService.getNewsForSearch({
         offset: +offset,
         limit: +limit,
         tickers: this.getTickerArray(tickers),
       });
+
+      console.log(news);
 
       if (news) {
         return response.status(200).send(news);
@@ -301,7 +311,25 @@ export class ApiController {
         // tickers: this.getTickerArray(tickers),
       });
 
-      console.log(analyses, 'ana');
+      if (analyses) {
+        return response.status(200).send(analyses);
+      }
+
+      response.sendStatus(404);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  @GetMapping({ path: '/search/analyses' })
+  public async getAnalysesForSearch(request: Request, response: Response) {
+    try {
+      const { offset, limit, tickers } = request.query;
+      const analyses = await this.articleService.getOpinionsForSearch({
+        offset: +offset,
+        limit: +limit,
+        // tickers: this.getTickerArray(tickers),
+      });
 
       if (analyses) {
         return response.status(200).send(analyses);

--- a/packages/karl/backend/controller/api/ApiController.ts
+++ b/packages/karl/backend/controller/api/ApiController.ts
@@ -23,6 +23,11 @@ export class ApiController {
     @Inject(BookmarkService) private bookmarkService: BookmarkService,
   ) {}
 
+  private getTickerArray(tickers: any) {
+    if (typeof tickers === 'string') return [tickers];
+    return tickers;
+  }
+
   @GetMapping({ path: '/user' })
   public async getUser(request: Request, response: Response) {
     try {
@@ -247,7 +252,28 @@ export class ApiController {
   @GetMapping({ path: '/articles/news' })
   public async getNews(request: Request, response: Response) {
     try {
-      const news = await this.articleService.getNews(request.body);
+      const { offset, limit, tickers } = request.query;
+      const news = await this.articleService.getNews({ offset: +offset, limit: +limit, tickers: this.getTickerArray(tickers) });
+
+      if (news) {
+        return response.status(200).send(news);
+      }
+
+      response.sendStatus(404);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  @GetMapping({ path: '/search/news' })
+  public async getNewsForSearch(request: Request, response: Response) {
+    try {
+      const { offset, limit, tickers } = request.query;
+      const news = await this.articleService.getNewsForSearch({
+        offset: +offset,
+        limit: +limit,
+        tickers: this.getTickerArray(tickers),
+      });
 
       if (news) {
         return response.status(200).send(news);
@@ -268,7 +294,14 @@ export class ApiController {
   @GetMapping({ path: '/articles/analyses' })
   public async getAnalyses(request: Request, response: Response) {
     try {
-      const analyses = await this.articleService.getOpinions(request.body);
+      const { offset, limit, tickers } = request.query;
+      const analyses = await this.articleService.getOpinions({
+        offset: +offset,
+        limit: +limit,
+        // tickers: this.getTickerArray(tickers),
+      });
+
+      console.log(analyses, 'ana');
 
       if (analyses) {
         return response.status(200).send(analyses);


### PR DESCRIPTION
##작업내용
* 검색 페이지를 위한 뉴스 및 분석 데이터를 가져오는 controller, service 개발
* 받아온 데이터 화면에 렌더링

##todo
* service에 regex 적용하기
* 검색이 제대로 안되는 버그 fix
* 리팩토링
* 뉴스 페이지, 분석 페이지에도 렌더링하도록 개발
![Animation](https://user-images.githubusercontent.com/41279460/120880447-99a81e00-c605-11eb-9f91-307de5d6464e.gif)
