### PR TITLE
[fix] market, itemdetail page bug fix

### DIFF
--- a/packages/common/backend/service/BookmarkService.ts
+++ b/packages/common/backend/service/BookmarkService.ts
@@ -1,5 +1,6 @@
 import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import Bookmark from '../model/BookmarkModel';
+import { investing } from 'investing-com-api';
 
 interface createBookmarkQueryProps {
   email: string;
@@ -30,7 +31,6 @@ export default class BookmarkService {
   public async createBookmark({ email, symbol, name, category }: createBookmarkQueryProps) {
     const bookmark = await Bookmark.findOne({ email, symbol, name, category });
 
-    console.log(bookmark);
     if (bookmark) {
       return false;
     }

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -5,14 +5,14 @@ declare const Axios: AxiosStatic;
 const devURL = 'http://localhost:3000';
 
 enum tickersMap {
-  DOW_JONES_30 = 'AAPL',
-  NASDAQ_100 = 'AAPL',
-  FRANCE_40 = 'AAPL',
-  NIKKEI_255 = 'AAPL',
-  BIT_COIN = 'AAPL',
-  LITE_COIN = 'AAPL',
-  ETHEREUM = 'AAPL',
-  IOTA = 'AAPL',
+  DOW_JONES_30 = 'TSLA',
+  NASDAQ_100 = 'NVDA',
+  FRANCE_40 = 'DOCU',
+  NIKKEI_255 = 'MSFT',
+  BIT_COIN = 'ZM',
+  LITE_COIN = 'EBAY',
+  ETHEREUM = 'MOS',
+  IOTA = 'AAL',
 }
 
 export interface getSearchedItemsInfo {
@@ -115,6 +115,8 @@ const getSearchedAnalyses = async ({ offset, limit, tickers }: getNewsAndAnalyse
  */
 const getItemDetail = async ({ symbols, email }: getItemDetailInfo) => {
   try {
+    let isStock = true;
+
     const result = await Axios.get(`${devURL}/api/item-detail`, {
       params: {
         symbols: tickersMap[symbols] ? tickersMap[symbols] : symbols,
@@ -122,8 +124,13 @@ const getItemDetail = async ({ symbols, email }: getItemDetailInfo) => {
       },
     });
 
+    if (tickersMap[symbols]) {
+      isStock = false;
+    }
+
     if (result.status === 200) {
       const { data: itemDetail } = result;
+      itemDetail.isStock = isStock;
 
       return itemDetail;
     }

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -4,6 +4,17 @@ declare const Axios: AxiosStatic;
 
 const devURL = 'http://localhost:3000';
 
+enum tickersMap {
+  DOW_JONES_30 = 'AAPL',
+  NASDAQ_100 = 'AAPL',
+  FRANCE_40 = 'AAPL',
+  NIKKEI_255 = 'AAPL',
+  BIT_COIN = 'AAPL',
+  LITE_COIN = 'AAPL',
+  ETHEREUM = 'AAPL',
+  IOTA = 'AAPL',
+}
+
 export interface getSearchedItemsInfo {
   keyword: string;
   email: string;
@@ -104,7 +115,12 @@ const getSearchedAnalyses = async ({ offset, limit, tickers }: getNewsAndAnalyse
  */
 const getItemDetail = async ({ symbols, email }: getItemDetailInfo) => {
   try {
-    const result = await Axios.get(`${devURL}/api/item-detail?symbols=${symbols}&email=${email}`);
+    const result = await Axios.get(`${devURL}/api/item-detail`, {
+      params: {
+        symbols: tickersMap[symbols] ? tickersMap[symbols] : symbols,
+        email,
+      },
+    });
 
     if (result.status === 200) {
       const { data: itemDetail } = result;

--- a/packages/common/frontend/components/ItemCard.vue
+++ b/packages/common/frontend/components/ItemCard.vue
@@ -134,7 +134,7 @@ export default {
 
   methods: {
     routeToItemDetail() {
-      this.$router.push({ path: 'item-detail', query: { symbols: this.symbol } });
+      this.$router.push({ path: 'item-detail', query: { symbols: this.symbol, name: this.name } });
     },
   },
 };

--- a/packages/common/frontend/components/ItemCard.vue
+++ b/packages/common/frontend/components/ItemCard.vue
@@ -124,19 +124,11 @@ export default {
     },
 
     fluctuationPrice() {
-      if (!this.isBookmark) {
-        return this.item.diff.toFixed(3);
-      }
-
-      return 10;
+      return this.item.diff.toFixed(3);
     },
 
     fluctuationRate() {
-      if (!this.isBookmark) {
-        return this.item.growthRate.toFixed(3);
-      }
-
-      return 10;
+      return this.item.growthRate.toFixed(3);
     },
   },
 

--- a/packages/common/frontend/components/MultipurposeHeader.vue
+++ b/packages/common/frontend/components/MultipurposeHeader.vue
@@ -8,7 +8,7 @@
         <div>
           <custom-text>{{ name }}</custom-text>
         </div>
-        <div>
+        <div v-if="isStock">
           <custom-text>{{ category }} ({{ symbol }})</custom-text>
         </div>
       </div>
@@ -129,6 +129,10 @@ export default {
 
     email() {
       return this.userInfo.userEmail;
+    },
+
+    isStock() {
+      return this.itemDetail.isStock;
     },
   },
 

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -82,7 +82,20 @@ const actions = {
 // mutatuons 설정
 const mutations = {
   setItemDetail(state, { itemDetail, name }) {
-    const { symbol, adj_close, adj_high, adj_low, close, open, volume, stock_exchange, high, low, isBookmarked } = itemDetail;
+    const {
+      symbol,
+      adj_close,
+      adj_high,
+      adj_low,
+      close,
+      open,
+      volume,
+      stock_exchange,
+      high,
+      low,
+      isBookmarked,
+      isStock,
+    } = itemDetail;
 
     state.itemDetail = {
       ...state.itemDetail,
@@ -99,6 +112,7 @@ const mutations = {
       high,
       low,
       isBookmarked,
+      isStock,
     };
   },
 

--- a/packages/common/frontend/store/modules/itemDetail.ts
+++ b/packages/common/frontend/store/modules/itemDetail.ts
@@ -30,12 +30,12 @@ const getters = {};
 
 // actions 설정
 const actions = {
-  async getItemDetail({ commit }, { symbols, email }) {
+  async getItemDetail({ commit }, { symbols, email, name }) {
     try {
       const itemDetail = await getItemDetail({ symbols, email });
 
       if (itemDetail) {
-        commit('changeItemDetail', itemDetail);
+        commit('setItemDetail', { itemDetail, name });
 
         return true;
       }
@@ -51,7 +51,7 @@ const actions = {
       const news = await getNews({ offset, limit, tickers });
 
       if (news) {
-        commit('changeNews', news);
+        commit('setNews', news);
 
         return true;
       }
@@ -67,7 +67,7 @@ const actions = {
       const analyses = await getAnalyses({ offset, limit, tickers });
 
       if (analyses) {
-        commit('changeAnalyses', analyses);
+        commit('setAnalyses', analyses);
 
         return true;
       }
@@ -81,21 +81,8 @@ const actions = {
 
 // mutatuons 설정
 const mutations = {
-  changeItemDetail(state, itemDetail) {
-    const {
-      name,
-      symbol,
-      adj_close,
-      adj_high,
-      adj_low,
-      close,
-      open,
-      volume,
-      stock_exchange,
-      high,
-      low,
-      isBookmarked,
-    } = itemDetail;
+  setItemDetail(state, { itemDetail, name }) {
+    const { symbol, adj_close, adj_high, adj_low, close, open, volume, stock_exchange, high, low, isBookmarked } = itemDetail;
 
     state.itemDetail = {
       ...state.itemDetail,
@@ -115,11 +102,11 @@ const mutations = {
     };
   },
 
-  changeNews(state, news) {
+  setNews(state, news) {
     state.news = news;
   },
 
-  changeAnalyses(state, analyses) {
+  setAnalyses(state, analyses) {
     state.analyses = analyses;
   },
 };

--- a/packages/common/frontend/views/ItemDetail.vue
+++ b/packages/common/frontend/views/ItemDetail.vue
@@ -126,11 +126,11 @@ export default {
   },
 
   created() {
-    const { symbols } = this.$route.query;
+    const { symbols, name } = this.$route.query;
     const email = this.userInfo.userEmail;
     const tickers = [symbols];
 
-    this.getItemDetail({ symbols, email });
+    this.getItemDetail({ symbols, email, name });
     this.getNews({ offset: 0, limit: 20, tickers });
     this.getAnalyses({ offset: 0, limit: 20, tickers });
   },

--- a/packages/karl/frontend/store/modules/market.ts
+++ b/packages/karl/frontend/store/modules/market.ts
@@ -6,7 +6,7 @@ enum tickersMap {
   FRANCE_40 = 'France 40',
   NIKKEI_255 = 'Nikkei 255',
   BIT_COIN = 'BIT COIN',
-  LITE_COIN = 'LITE_COIN',
+  LITE_COIN = 'LITE COIN',
   ETHEREUM = 'ETHEREUM',
   IOTA = 'IOTA',
 }
@@ -93,7 +93,7 @@ const mutations = {
     indices.forEach((index) => {
       const { key, value, diff, growthRate, date } = index;
 
-      indicesItems.push({ key, name: tickersMap[key], value, diff, growthRate, date, category: categoryMap[key] });
+      indicesItems.push({ key, name: tickersMap[key], value, diff, growthRate, date, category: categoryMap[key], symbol: key });
     });
 
     state.indicesItems = indicesItems;
@@ -105,7 +105,16 @@ const mutations = {
     cryptos.forEach((crypto) => {
       const { key, value, diff, growthRate, date } = crypto;
 
-      cryptoItems.push({ key, name: tickersMap[key], value, diff, growthRate, date, category: categoryMap['CRYPTO'] });
+      cryptoItems.push({
+        key,
+        name: tickersMap[key],
+        value,
+        diff,
+        growthRate,
+        date,
+        category: categoryMap['CRYPTO'],
+        symbol: key,
+      });
     });
 
     state.cryptoItems = cryptoItems;

--- a/packages/karl/frontend/store/modules/market.ts
+++ b/packages/karl/frontend/store/modules/market.ts
@@ -5,10 +5,10 @@ enum tickersMap {
   NASDAQ_100 = 'Nasdaq 100',
   FRANCE_40 = 'France 40',
   NIKKEI_255 = 'Nikkei 255',
-  BIT_COIN = 'BIT COIN',
-  LITE_COIN = 'LITE COIN',
-  ETHEREUM = 'ETHEREUM',
-  IOTA = 'IOTA',
+  BIT_COIN = 'Bit coin',
+  LITE_COIN = 'Lite coin',
+  ETHEREUM = 'Ethereum',
+  IOTA = 'Iota',
 }
 
 enum categoryMap {


### PR DESCRIPTION
## 작업내용
* market 페이지에 지수, 주식, 가상화페 등락의 정도, 등락률 렌더링하게끔 fix
* item detail 페이지에서 주식이 아닐 경우 category와 symbol이 렌더링안되게 끔 함(가상화폐, 지수들이 실제론 주식정보를 갖고오기 때문에)

## todo
* 차트 라이브러리 이식
* item detail 페이지에 historical data연동, market 페이지에 실시간 등락 연동하기
* news page 만들기