### PR TITLE
Add components from article detail view

### DIFF
--- a/packages/common/frontend/components/ArticleDetail/ArticleDetailBodyImage.vue
+++ b/packages/common/frontend/components/ArticleDetail/ArticleDetailBodyImage.vue
@@ -1,0 +1,22 @@
+<template>
+  <img :src="src" :class="$style.img" />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  props: {
+    src: {
+      type: String,
+      required: true,
+    },
+  },
+});
+</script>
+
+<style lang="scss" module>
+.img {
+  width: 100%;
+}
+</style>

--- a/packages/common/frontend/components/ArticleDetail/ArticleDetailBodyText.vue
+++ b/packages/common/frontend/components/ArticleDetail/ArticleDetailBodyText.vue
@@ -1,0 +1,17 @@
+<template>
+  <p :class="$style.text">
+    <slot />
+  </p>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({});
+</script>
+
+<style lang="scss" module>
+.text {
+  padding: 20px 0;
+}
+</style>

--- a/packages/common/frontend/components/ArticleDetail/ArticleDetailSection.vue
+++ b/packages/common/frontend/components/ArticleDetail/ArticleDetailSection.vue
@@ -1,0 +1,17 @@
+<template>
+  <section :class="$style.section">
+    <slot />
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({});
+</script>
+
+<style lang="scss" module>
+.section {
+  padding: 12px;
+}
+</style>

--- a/packages/common/frontend/components/ArticleDetail/ArticleDetailSubInfo.vue
+++ b/packages/common/frontend/components/ArticleDetail/ArticleDetailSubInfo.vue
@@ -1,0 +1,19 @@
+<template>
+  <p :class="$style.info">
+    <slot />
+  </p>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({});
+</script>
+
+<style lang="scss" module>
+.info {
+  border-bottom: 1px solid gray;
+  padding-bottom: 8px;
+  word-break: keep-all;
+}
+</style>

--- a/packages/common/frontend/components/ArticleDetail/ArticleDetailTitle.vue
+++ b/packages/common/frontend/components/ArticleDetail/ArticleDetailTitle.vue
@@ -1,0 +1,17 @@
+<template>
+  <h3 :class="$style.title">
+    <slot />
+  </h3>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({});
+</script>
+
+<style lang="scss" module>
+.title {
+  margin-bottom: 12px;
+}
+</style>

--- a/packages/common/frontend/components/ArticleDetail/index.ts
+++ b/packages/common/frontend/components/ArticleDetail/index.ts
@@ -1,0 +1,7 @@
+import ArticleDetailSection from './ArticleDetailSection.vue';
+import ArticleDetailTitle from './ArticleDetailTitle.vue';
+import ArticleDetailSubInfo from './ArticleDetailSubInfo.vue';
+import ArticleDetailBodyImage from './ArticleDetailBodyImage.vue';
+import ArticleDetailBodyText from './ArticleDetailBodyText.vue';
+
+export { ArticleDetailSection, ArticleDetailTitle, ArticleDetailSubInfo, ArticleDetailBodyText, ArticleDetailBodyImage };

--- a/packages/dogyeong/src/frontend/App.vue
+++ b/packages/dogyeong/src/frontend/App.vue
@@ -36,7 +36,9 @@ export default Vue.extend({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+@import '@/styles/index.scss';
+
 #app {
   background-color: var(--app-bg-color);
   overflow: hidden;

--- a/packages/dogyeong/src/frontend/main.ts
+++ b/packages/dogyeong/src/frontend/main.ts
@@ -3,7 +3,6 @@ import 'zum-portal-core/frontend';
 import App from '@/App.vue';
 import createRouter from '@/router';
 import createStore from '@/store';
-import '@/styles/index.scss';
 import 'swiper/swiper-bundle.css';
 
 Vue.prototype._$router = createRouter();

--- a/packages/dogyeong/src/frontend/styles/index.scss
+++ b/packages/dogyeong/src/frontend/styles/index.scss
@@ -1,4 +1,2 @@
-// @import "mixin";
 @import 'variables';
 @import 'base';
-// @import "common";

--- a/packages/dogyeong/src/frontend/views/NewsDetail.vue
+++ b/packages/dogyeong/src/frontend/views/NewsDetail.vue
@@ -12,20 +12,20 @@
       </HeaderTitle>
     </Header>
     <main v-if="isLoading">
-      <div class="message">loading...</div>
+      <div :class="$style.message">loading...</div>
     </main>
     <main v-else-if="isError">
-      <div class="message">Error!</div>
+      <div :class="$style.message">Error!</div>
     </main>
     <main v-else>
-      <section class="article-header">
-        <h3 class="article-title">{{ article.title }}</h3>
-        <p class="article-info">{{ article.source }} | {{ article.date | formatDate }}</p>
-      </section>
-      <section class="article-main">
-        <img class="article-img" :src="article.image_url" />
-        <p class="article-text">{{ article.text }}</p>
-      </section>
+      <ArticleDetailSection>
+        <ArticleDetailTitle>{{ article.title }}</ArticleDetailTitle>
+        <ArticleDetailSubInfo :class="$style.sub">{{ article.source }} | {{ article.date | formatDate }}</ArticleDetailSubInfo>
+      </ArticleDetailSection>
+      <ArticleDetailSection>
+        <ArticleDetailBodyImage :src="article.image_url" />
+        <ArticleDetailBodyText>{{ article.text }}</ArticleDetailBodyText>
+      </ArticleDetailSection>
     </main>
     <BottomNav></BottomNav>
   </Layout>
@@ -38,6 +38,13 @@ import { Header, HeaderTitle, HeaderButton } from '@/components/Header';
 import Layout from '@/components/Layout/Layout.vue';
 import { getArticle } from '@/services/articleService';
 import { fromNow } from 'common/frontend/utils';
+import {
+  ArticleDetailSection,
+  ArticleDetailTitle,
+  ArticleDetailSubInfo,
+  ArticleDetailBodyText,
+  ArticleDetailBodyImage,
+} from 'common/frontend/components/ArticleDetail';
 
 export default Vue.extend({
   name: 'NewsDetail',
@@ -48,6 +55,11 @@ export default Vue.extend({
     HeaderTitle,
     Layout,
     HeaderButton,
+    ArticleDetailSection,
+    ArticleDetailTitle,
+    ArticleDetailSubInfo,
+    ArticleDetailBodyText,
+    ArticleDetailBodyImage,
   },
 
   filters: {
@@ -93,35 +105,13 @@ export default Vue.extend({
 });
 </script>
 
-<style lang="scss" scoped>
-main {
-  .article-header {
-    padding: 12px;
+<style lang="scss" module>
+.sub {
+  border-color: var(--border-color);
+}
 
-    .article-title {
-      margin-bottom: 12px;
-    }
-    .article-info {
-      border-bottom: 1px solid var(--border-color);
-      padding-bottom: 8px;
-      word-break: keep-all;
-    }
-  }
-
-  .article-main {
-    padding: 12px;
-
-    .article-img {
-      width: 100%;
-    }
-    .article-text {
-      padding: 20px 0;
-    }
-  }
-
-  .message {
-    padding: 12px;
-    font-size: 18px;
-  }
+.message {
+  padding: 12px;
+  font-size: 18px;
 }
 </style>


### PR DESCRIPTION
## 작업내용

- 뉴스 상세페이지에서 사용할 공용 컴포넌트 추가

## Example

```vue
import {
  ArticleDetailSection,
  ArticleDetailTitle,
  ArticleDetailSubInfo,
  ArticleDetailBodyText,
  ArticleDetailBodyImage,
} from 'common/frontend/components/ArticleDetail';

...

<ArticleDetailSection>
  <ArticleDetailTitle>{{ article.title }}</ArticleDetailTitle>
  <ArticleDetailSubInfo>{{ article.source }} | {{ article.date | formatDate }}</ArticleDetailSubInfo>
</ArticleDetailSection>
<ArticleDetailSection>
  <ArticleDetailBodyImage :src="article.image_url" />
  <ArticleDetailBodyText>{{ article.text }}</ArticleDetailBodyText>
</ArticleDetailSection>
```

## Screenshots

![image](https://user-images.githubusercontent.com/40662323/121281545-03c90780-c913-11eb-9e61-d12acb14db2c.png)

