### PR TITLE
Feat: 주식 상세 페이지 컴포넌트 구현

### DIFF
--- a/packages/wiii/backend/service/chart/KRX.ts
+++ b/packages/wiii/backend/service/chart/KRX.ts
@@ -150,11 +150,12 @@ const adjustPrices = (_result) => {
 
   const [last, prev] = adjusted;
   const price = last['adj_close'];
+  const volume = last.volume;
   const prevPrice = prev['adj_close'];
   const change = Number((((price - prevPrice) / prevPrice) * 100).toFixed(2));
   const typeName = `stock`;
 
-  return { results: adjusted, count, payload: { total }, change, price, typeName };
+  return { results: adjusted, count, payload: { total }, change, price, typeName, volume };
 };
 
 /**

--- a/packages/wiii/frontend/components/atoms/Words.vue
+++ b/packages/wiii/frontend/components/atoms/Words.vue
@@ -17,7 +17,6 @@ export default Vue.extend({});
   height: 100%;
   text-align: center;
   font-size: 1rem;
-  line-height: 1.5;
 
   color: inherit;
   background-color: transparent;

--- a/packages/wiii/frontend/components/organisms/StockDetailCompanyInfo.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailCompanyInfo.vue
@@ -1,0 +1,148 @@
+<template>
+  <div id="stock-detail-company-info">
+    <Words class="stock-detail-company-subtitle">기업개요</Words>
+    <section class="stock-detail-company">
+      <Words class="stock-detail-company-text head"> 홈페이지 </Words>
+      <Words class="stock-detail-company-text link" @click.native="openUrl"> {{ weburl }} </Words>
+      <Words class="stock-detail-company-text head"> 대표전화 </Words>
+      <Words class="stock-detail-company-text"> {{ phone }} </Words>
+      <Words class="stock-detail-company-text head"> 상장일 </Words>
+      <Words class="stock-detail-company-text"> {{ ipo }} </Words>
+      <Words class="stock-detail-company-text head"> 거래소 </Words>
+      <Words class="stock-detail-company-text"> {{ exchangeKR }} </Words>
+    </section>
+
+    <Words class="stock-detail-company-subtitle">투자지표</Words>
+    <section class="stock-detail-company">
+      <Words class="stock-detail-company-text head"> 최근 결산 연도 EPS </Words>
+      <Words class="stock-detail-company-text"> {{ `${eps.v.toFixed(2)} (${eps.period})` }} </Words>
+      <Words class="stock-detail-company-text head"> 최근 3년 평균 EPS 성장률 </Words>
+      <Words class="stock-detail-company-text"> {{ epsGrowth3Y }} </Words>
+      <Words class="stock-detail-company-text head"> PBR </Words>
+      <Words class="stock-detail-company-text"> {{ pbAnnual }} </Words>
+      <Words class="stock-detail-company-text head"> ROE </Words>
+      <Words class="stock-detail-company-text"> {{ roeRfy }} </Words>
+      <Words class="stock-detail-company-text head"> 1주당 배당금 </Words>
+      <Words class="stock-detail-company-text"> {{ dps }}원 </Words>
+      <Words class="stock-detail-company-text head"> 배당수익률 </Words>
+      <Words class="stock-detail-company-text"> {{ dpsRate }}% </Words>
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Words from '@/components/atoms/Words.vue';
+
+export default Vue.extend({
+  name: 'StockDetailCompanyInfo',
+
+  components: { Words },
+
+  props: {
+    weburl: {
+      type: String,
+    },
+    ipo: {
+      type: String,
+    },
+    exchange: {
+      type: String,
+    },
+    phone: {
+      type: String,
+    },
+    eps: {
+      type: Object,
+      default: () => {
+        v: 0;
+        period: '';
+      },
+    },
+    epsGrowth3Y: {
+      type: String,
+    },
+    pbAnnual: {
+      type: String,
+    },
+    roiAnnual: {
+      type: String,
+    },
+    roeRfy: {
+      type: String,
+    },
+    peer: {
+      type: Array,
+      default: () => [],
+    },
+    dps: {
+      type: String,
+    },
+    dpsRate: {
+      type: String,
+    },
+  },
+
+  computed: {
+    exchangeKR() {
+      return this.exchange.includes('KOREA EXCHANGE') ? '한국거래소' : '';
+    },
+  },
+
+  methods: {
+    openUrl() {
+      window.open(this.weburl);
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+$dark-green: $neon-green;
+
+.stock-detail-company-info {
+  width: 100%;
+}
+
+.stock-detail-company {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 2fr 3fr 2fr 3fr;
+  grid-auto-rows: minmax(1.2rem, auto);
+  justify-content: center;
+
+  &-subtitle {
+    margin-top: 5px;
+    padding: 5px;
+    width: max-content;
+
+    font-size: 1.1rem;
+    text-align: left;
+    color: $grey-700;
+
+    .dark & {
+      color: $dark-green;
+    }
+  }
+
+  &-text {
+    font-size: 0.9rem;
+    color: $grey-900;
+    text-align: left;
+
+    &.head {
+      font-weight: bolder;
+    }
+
+    &.link {
+      cursor: pointer;
+      font-style: oblique;
+      text-decoration: underline;
+    }
+
+    .dark & {
+      color: rgba($dark-green, 0.6);
+    }
+  }
+}
+</style>

--- a/packages/wiii/frontend/components/organisms/StockDetailCompanyInfo.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailCompanyInfo.vue
@@ -117,6 +117,7 @@ $dark-green: $neon-green;
     width: max-content;
 
     font-size: 1.1rem;
+    font-weight: bold;
     text-align: left;
     color: $grey-700;
 

--- a/packages/wiii/frontend/components/organisms/StockDetailHeader.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailHeader.vue
@@ -1,0 +1,89 @@
+<template>
+  <div id="stocks-detail-header" class="card">
+    <img :src="logo" height="35px" alt="" />
+    <Words id="stocks-detail-header-tickerName">{{ tickerName }}</Words>
+    <Words id="stocks-detail-header-price" :class="colorClass">현재가 {{ price.toLocaleString() }}원 </Words>
+    <Words id="stocks-detail-header-change" :class="colorClass"> ({{ changeSign }}{{ change }}%) </Words>
+    <Words id="stocks-detail-header-price " class="same"> 거래량 {{ volume.toLocaleString() }}주 </Words>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Words from '@/components/atoms/Words.vue';
+
+export default Vue.extend({
+  name: 'StockDetailHeader',
+
+  components: { Words },
+
+  props: {
+    logo: {
+      type: String,
+    },
+    tickerName: {
+      type: String,
+    },
+    price: {
+      type: Number,
+    },
+    volume: {
+      type: Number,
+    },
+    change: {
+      type: Number,
+    },
+  },
+
+  computed: {
+    changeSign() {
+      return this.change > 0 ? '+' : '';
+    },
+
+    colorClass() {
+      return this.change > 0 ? 'up' : this.change < 0 ? 'down' : 'same';
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+#stocks-detail-header {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 50px 4fr 2fr 1fr 3fr;
+  column-gap: 15px;
+
+  .pure-text {
+    display: grid;
+    place-content: center;
+  }
+
+  &-tickerName {
+    color: $grey-700;
+    font-weight: 700;
+    font-size: 1.45rem;
+    text-align: left;
+
+    .dark & {
+      color: $grey-100;
+    }
+  }
+
+  &-change {
+    font-size: 0.9rem;
+  }
+}
+
+.up {
+  color: $red-700;
+}
+
+.down {
+  color: $blue-500;
+}
+
+.same {
+  color: $grey-500;
+}
+</style>

--- a/packages/wiii/frontend/components/organisms/StockDetailPriceSummary.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailPriceSummary.vue
@@ -38,7 +38,7 @@ export default Vue.extend({
     font-size: 0.75rem;
 
     &.up {
-      color: $red-a400;
+      color: $red-700;
     }
 
     &.down {

--- a/packages/wiii/frontend/components/organisms/StockDetailPriceSummary.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailPriceSummary.vue
@@ -1,8 +1,8 @@
 <template>
   <section id="stocks-detail-header-summary" class="noselect">
-    <Words class="mini"> 시가총액: {{ marketCapitalization }}원</Words>
-    <Words class="mini"> 52주 최고가: {{ week52High }}원</Words>
-    <Words class="mini"> 52주 최저가: {{ week52Low }}</Words>
+    <Words class="stocks-detail-header-price"> 시가총액: {{ marketCapitalization }}</Words>
+    <Words class="stocks-detail-header-price up"> 52주 최고가: {{ week52High }} 원</Words>
+    <Words class="stocks-detail-header-price down"> 52주 최저가: {{ week52Low }} 원</Words>
   </section>
 </template>
 
@@ -33,5 +33,17 @@ export default Vue.extend({
 #stocks-detail-header-summary {
   display: flex;
   justify-content: space-around;
+
+  .stocks-detail-header-price {
+    font-size: 0.75rem;
+
+    &.up {
+      color: $red-a400;
+    }
+
+    &.down {
+      color: $blue-500;
+    }
+  }
 }
 </style>

--- a/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
+++ b/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="area">
     <!-- 상단 시세 요약 -->
-    <div id="stocks-detail-header" class="card">
-      <img v-show="logo" :src="logo" height="35px" />
-      <Words id="stocks-detail-header-tickerName">{{ tickerName }}</Words>
-      <Words id="stocks-detail-header-price" :class="colorClass">현재가 {{ price }}원 </Words>
-      <Words id="stocks-detail-header-change" :class="colorClass"> ({{ changeSign }}{{ change }}%) </Words>
-    </div>
+    <Header v-bind="{ ...headerInfo }" />
     <PriceSummary v-bind="{ ...priceSummary }" />
     <Chart class="card" :typeName="`stock`" :apiType="`es`" :ticker="ticker" />
 
@@ -22,8 +17,8 @@
 import Vue from 'vue';
 import { createNamespacedHelpers } from 'vuex';
 
-import Words from '@/components/atoms/Words.vue';
 import Chart from '@/components/molecules/Chart.vue';
+import Header from '@/components/organisms/StockDetailHeader.vue';
 import PriceSummary from '@/components/organisms/StockDetailPriceSummary.vue';
 import CompanyInfo from '@/components/organisms/StockDetailCompanyInfo.vue';
 import ReplySection from '@/components/organisms/ReplySection.vue';
@@ -55,9 +50,9 @@ const adjMarketCap = (cap: number) =>
 
 export default Vue.extend({
   components: {
-    Words,
-    Chart,
+    Header,
     PriceSummary,
+    Chart,
     CompanyInfo,
     ReplySection,
   },
@@ -71,7 +66,7 @@ export default Vue.extend({
 
   data() {
     return {
-      logo: undefined,
+      headerInfo: {},
       priceSummary: {},
       companyInfo: {},
     };
@@ -88,20 +83,17 @@ export default Vue.extend({
       return this.stockData[this.ticker].price;
     },
 
+    volume() {
+      return this.stockData[this.ticker].volume;
+    },
+
     change() {
       return this.stockData[this.ticker].change;
-    },
-
-    changeSign() {
-      return this.change > 0 ? '+' : '';
-    },
-
-    colorClass() {
-      return this.change > 0 ? 'up' : this.change < 0 ? 'down' : 'same';
     },
   },
 
   beforeMount() {
+    const { ticker, tickerName, price, change, volume, stockOverviews } = this;
     const {
       metric: {
         metric,
@@ -109,12 +101,18 @@ export default Vue.extend({
       },
       peer,
       profile: { ipo, phone, weburl, marketCapitalization, logo, exchange },
-    } = this.stockOverviews[this.ticker];
+    } = stockOverviews[ticker];
 
     const { epsGrowth3Y, pbAnnual, roeRfy, roiAnnual, dividendPerShareAnnual, dividendYieldIndicatedAnnual } = metric;
     const { eps } = annual;
 
-    this.logo = logo;
+    this.headerInfo = {
+      logo,
+      tickerName,
+      price,
+      volume,
+      change,
+    };
 
     this.priceSummary = {
       marketCapitalization: adjMarketCap(marketCapitalization),
@@ -144,39 +142,5 @@ export default Vue.extend({
 main.area {
   display: grid;
   place-content: center;
-}
-
-#stocks-detail-header {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-
-  .pure-text {
-    width: max-content;
-  }
-
-  &-tickerName {
-    color: $grey-700;
-    font-weight: 700;
-  }
-
-  &-price {
-  }
-
-  &-change {
-    font-size: 0.7rem;
-  }
-}
-
-.up {
-  color: $red-700;
-}
-
-.down {
-  color: $blue-700;
-}
-
-.same {
-  color: inherit;
 }
 </style>

--- a/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
+++ b/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
@@ -46,6 +46,12 @@ const phoneReplacer = (_phone: string) => {
 
   return phone.replace(phoneReg, (_, n1, n2, n3, n4) => `+${n1}) ` + [`0${n2}`, n3, n4].join('-'));
 };
+const adjMarketCap = (cap: number) =>
+  cap > 1000000
+    ? Math.floor(cap / 100)
+        .toString()
+        .replace(/(\d+)(\d{4})/, (_, n1, n2) => `${n1}조 ${Number(n2).toLocaleString()}억원`)
+    : `${(cap / 100).toLocaleString()} 억원`;
 
 export default Vue.extend({
   components: {
@@ -111,7 +117,7 @@ export default Vue.extend({
     this.logo = logo;
 
     this.priceSummary = {
-      marketCapitalization: marketCapitalization.toLocaleString(),
+      marketCapitalization: adjMarketCap(marketCapitalization),
       week52High: metric['52WeekHigh'].toLocaleString(),
       week52Low: metric['52WeekLow'].toLocaleString(),
     };


### PR DESCRIPTION
## Feat: 주식 상세 페이지 컴포넌트 구현

![image](https://user-images.githubusercontent.com/57997672/122357493-c574bd80-cf8e-11eb-85d7-3822b20a8030.png)

기본 테마

![image](https://user-images.githubusercontent.com/57997672/122357676-e76e4000-cf8e-11eb-838b-c49c6501f5c8.png)

다크 테마

#124 에 이어 상세페이지 컴포넌트 구현 완료
- display: flex 로 기업/종목 정보 정렬
