### PR TITLE
Fix: common 댓글 입력 누락된 props 추가, 좋아요 UI, module 추가

### DIFF
--- a/packages/common/backend/service/ReplyService.ts
+++ b/packages/common/backend/service/ReplyService.ts
@@ -25,7 +25,7 @@ export default class ReplyService {
    * docId에 해당하는 부분은 각 담당자가 만든 모델, 스키마에 맞게 controller에서 입력
    * @example 종목 관련 댓글 검색 => `AAPL`, `005930.KRX` 등
    */
-  public async getAllReplsByDocId(docId: string, offset = 0, limit = 15): Promise<ReplyDoc[]> {
+  public async getAllReplsByDocId(docId: string, offset = 0, limit = 15, email?: string): Promise<ReplyDoc[]> {
     return await Reply.find({ docId })
       .sort({ updatedAt: 'desc' })
       .skip(offset)
@@ -37,5 +37,9 @@ export default class ReplyService {
 
   /** @todo 댓글 삭제 */
 
-  /** @todo 좋아요 토글링 */
+  /** @todo 좋아요 +1 */
+  public async toggleLike(props) {
+    const { replId } = props;
+    return Reply.findByIdAndUpdate(replId, { $inc: { likes: 1 } }).exec();
+  }
 }

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -229,7 +229,7 @@ export const getReplsByDocID = async (docId: string, email: string) => {
       data: { results },
       status,
       statusText,
-    } = await Axios.get(`/api/reply/${docId}?auth=${email}`);
+    } = await Axios.get(`/api/reply/${docId}`, { params: { email } });
 
     if (status >= 400) throw Error(statusText);
 

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -223,13 +223,13 @@ const refiner = (repls: ReplyDoc[]): IReply[] =>
     likes,
   }));
 
-export const getReplsByDocID = async (docId: string) => {
+export const getReplsByDocID = async (docId: string, email: string) => {
   try {
     const {
       data: { results },
       status,
       statusText,
-    } = await Axios.get(`/api/reply/${docId}`);
+    } = await Axios.get(`/api/reply/${docId}?auth=${email}`);
 
     if (status >= 400) throw Error(statusText);
 

--- a/packages/common/frontend/apis/index.ts
+++ b/packages/common/frontend/apis/index.ts
@@ -190,7 +190,7 @@ export interface CreateReplyProps {
   contents: string;
 }
 
-export const createReply = async ({ email, docId, contents }: CreateReplyProps) => {
+const createReply = async ({ email, docId, contents }: CreateReplyProps) => {
   try {
     const { status, statusText } = await Axios.post(`/api/reply`, { docId, email, contents });
     if (status >= 400) throw Error(statusText);
@@ -223,7 +223,7 @@ const refiner = (repls: ReplyDoc[]): IReply[] =>
     likes,
   }));
 
-export const getReplsByDocID = async (docId: string, email: string) => {
+const getReplsByDocID = async (docId: string, email: string) => {
   try {
     const {
       data: { results },
@@ -239,4 +239,23 @@ export const getReplsByDocID = async (docId: string, email: string) => {
   }
 };
 
-export { getSearchedItems, getItemDetail, getNews, getAnalyses, createBookmark, getBookmarks, deleteBookmark };
+/**
+ * 좋아요 추가/취소
+ * 서버에서 결과 응답 받을 필요 없이,
+ * 클라이언트에서 UI (+ debounce) 처리만
+ * @param replId 댓글 id
+ */
+const toggleLikes = (replId: string) => Axios.post(`/api/reply/likes`, { replId }, { withCredentials: true });
+
+export {
+  getSearchedItems,
+  getItemDetail,
+  getNews,
+  getAnalyses,
+  createBookmark,
+  getBookmarks,
+  deleteBookmark,
+  createReply,
+  getReplsByDocID,
+  toggleLikes,
+};

--- a/packages/common/frontend/components/ReplySection/index.vue
+++ b/packages/common/frontend/components/ReplySection/index.vue
@@ -1,13 +1,8 @@
 <template>
   <section class="section">
     <ReplySort :sortText="sortText" @change-sort="changeSort" />
-    <ReplyInput v-bind="{ curInputId, hasAuth }" @change-current-input="changeCurInput" @after-submit="afterSubmit" />
-    <Card
-      v-for="(repl, idx) in repls"
-      :key="idx"
-      v-bind="{ ...repl, curInputId, hasAuth }"
-      @change-current-input="changeCurInput"
-    />
+    <ReplyInput v-bind="{ docId, email }" @after-submit="afterSubmit" />
+    <Card v-for="(repl, idx) in repls" :key="idx" v-bind="{ ...repl, email }" />
   </section>
 </template>
 
@@ -29,10 +24,10 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    /** 사용자 로그인 정보; 로그인 된 사용자만 댓글 달기 가능 */
-    hasAuth: {
-      type: Boolean,
-      required: true,
+    /** 사용자 email; 로그인 된 사용자만 댓글 달기 가능 */
+    email: {
+      type: String,
+      default: undefined,
     },
   },
 
@@ -58,10 +53,6 @@ export default Vue.extend({
       this.sortIdx = (this.sortIdx + 1) % 2;
       this.sortText = this.sortTexts[this.sortIdx];
       this.repls = this.repls.sort((a, b) => (this.sortIdx === 0 ? b.date - a.date : b.likes - a.likes));
-    },
-
-    changeCurInput(idx: string) {
-      this.curInputId = idx;
     },
 
     async afterSubmit() {

--- a/packages/common/frontend/components/ReplySection/index.vue
+++ b/packages/common/frontend/components/ReplySection/index.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .reset {
   box-sizing: border-box;
   margin: 0;

--- a/packages/common/frontend/components/ReplySection/molecules/ReplyCard.vue
+++ b/packages/common/frontend/components/ReplySection/molecules/ReplyCard.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
       const { replId, liked, changableLikes } = this;
       this.liked = !liked;
       this.changableLikes = liked ? changableLikes - 1 : changableLikes + 1;
-      this.toggleLikesAction(replId);
+      if (!liked) this.toggleLikesAction(replId);
     },
   },
 });

--- a/packages/common/frontend/components/ReplySection/molecules/ReplyCard.vue
+++ b/packages/common/frontend/components/ReplySection/molecules/ReplyCard.vue
@@ -11,10 +11,10 @@
     </div>
     <Words class="reply-content"> {{ contents }} </Words>
     <div class="reply-reaction noselect">
-      <Button class="reply-likes">👍 {{ likes }}</Button>
-      <Button class="reply-rerepl" @click.native="inputToggle(replId)">대댓글 달기</Button>
+      <Button class="reply-likes" :class="{ 'reply-likes-added': liked }" @click.native="toggleLikes"
+        >👍 {{ changableLikes }}</Button
+      >
     </div>
-    <ReplyForm v-if="curInputId === replId" @change-current-input="inputToggle" />
   </article>
 </template>
 
@@ -24,15 +24,15 @@
  * @see https://semantic-ui.com/views/comment.html
  */
 import Vue from 'vue';
+import { mapActions } from 'vuex';
 import Button from '../atoms/Button.vue';
 import Words from '../atoms/Words.vue';
-import ReplyForm from './ReplyInputForm.vue';
 import lazyloading from '../../../utils/lazyloading';
 
 export default Vue.extend({
   name: 'ReplyCard',
 
-  components: { Button, Words, ReplyForm },
+  components: { Button, Words },
 
   /**
    * @see @/components/organisms/ReplySection
@@ -64,14 +64,21 @@ export default Vue.extend({
       type: Number,
       default: 0,
     },
-    curInputId: {
+    email: {
       type: String,
       required: true,
     },
-    hasAuth: {
+    userLike: {
       type: Boolean,
-      required: true,
+      default: false,
     },
+  },
+
+  data() {
+    return {
+      liked: this.userLike,
+      changableLikes: this.likes,
+    };
   },
 
   computed: {
@@ -88,14 +95,19 @@ export default Vue.extend({
   },
 
   mounted() {
-    const card = this.$refs.card;
-    lazyloading(card);
+    lazyloading(this.$refs.card);
   },
 
   methods: {
-    inputToggle(id: string | number) {
-      if (!this.hasAuth) return;
-      this.$emit('change-current-input', id);
+    ...mapActions('reply', ['toggleLikesAction']),
+
+    toggleLikes() {
+      /** @todo 예외처리 */
+      if (!this.email) return;
+      const { replId, liked, changableLikes } = this;
+      this.liked = !liked;
+      this.changableLikes = liked ? changableLikes - 1 : changableLikes + 1;
+      this.toggleLikesAction(replId);
     },
   },
 });
@@ -178,6 +190,11 @@ $maxHeight: 50px;
       text-align: center;
       font-weight: bold;
       color: rgba(249, 0, 79, 1);
+
+      &-added {
+        background-color: rgba(255, 23, 68, 0.6);
+        font-weight: bolder;
+      }
     }
   }
 }

--- a/packages/common/frontend/components/ReplySection/molecules/ReplyInputForm.vue
+++ b/packages/common/frontend/components/ReplySection/molecules/ReplyInputForm.vue
@@ -17,7 +17,18 @@ import Button from '../atoms/Button.vue';
 export default Vue.extend({
   components: { TextArea, Button },
 
-  /** @todo 현재 종목 또는 뉴스 ID props 또는 vuex에서 가져와야 함 */
+  props: {
+    docId: {
+      type: String,
+      required: true,
+    },
+
+    email: {
+      type: String,
+      required: true,
+    },
+  },
+
   data() {
     return {
       replyText: '',
@@ -37,7 +48,8 @@ export default Vue.extend({
     },
 
     async submitReply() {
-      const isInserted = await this.insertReply({ contents: this.replyText });
+      const { email, docId, replyText } = this;
+      const isInserted = await this.insertReply({ email, docId, contents: replyText });
       /** @todo 실패 UI */
       if (!isInserted) return;
 

--- a/packages/common/frontend/components/ReplySection/molecules/ReplyNewInput.vue
+++ b/packages/common/frontend/components/ReplySection/molecules/ReplyNewInput.vue
@@ -1,6 +1,6 @@
 <template>
-  <ReplyForm v-if="isValid" @change-current-input="inputToggle" @after-submit="$emit('after-submit')" />
-  <div v-else id="reply-open" class="card noselect" :class="{ disabled: !hasAuth }" @click="inputToggle(inputId)">
+  <ReplyForm v-if="isOpen" v-bind="{ docId, email }" @change-current-input="inputToggle" @after-submit="$emit('after-submit')" />
+  <div v-else id="reply-open" class="card noselect" :class="{ disabled: !formDisabled }" @click="inputToggle">
     <Words class="reply-valid-text"> {{ validText }} </Words>
   </div>
 </template>
@@ -14,41 +14,37 @@ export default Vue.extend({
   components: { Words, ReplyForm },
 
   props: {
-    curInputId: {
+    docId: {
       type: String,
       required: true,
     },
-    hasAuth: {
-      type: Boolean,
-      required: true,
+    email: {
+      type: String,
+      default: undefined,
     },
   },
 
   data() {
     return {
-      inputId: 'newReply',
+      isOpen: false,
     };
   },
 
   computed: {
-    isValid() {
-      const { curInputId, inputId } = this;
-      return this.hasAuth && curInputId === inputId;
-    },
-
     formDisabled() {
-      return this.hasAuth ? '' : 'disabled';
+      return this.email ? '' : 'disabled';
     },
 
     validText() {
-      return this.hasAuth ? `댓글 달기` : `댓글 달기는 로그인이 필요합니다`;
+      return this.email ? `댓글 달기` : `댓글 달기는 로그인이 필요합니다`;
     },
   },
 
   methods: {
-    inputToggle(id) {
-      if (!this.hasAuth) return this.$router.push(`/user/login`);
-      this.$emit('change-current-input', id);
+    inputToggle() {
+      const { email, isOpen } = this;
+      if (!email) return this.$router.push(`/user/login`);
+      this.isOpen = !isOpen;
     },
   },
 });

--- a/packages/common/frontend/store/modules/reply.ts
+++ b/packages/common/frontend/store/modules/reply.ts
@@ -26,9 +26,9 @@ const actions = {
    * 댓글 목록 조회
    * @param 종목 티커 또는 뉴스 id 로 조회
    */
-  getReplsByDocID: async (_, docId: string) => {
+  getReplsByDocID: async (_, { email, docId }) => {
     try {
-      const repls = await getReplsByDocID(docId);
+      const repls = await getReplsByDocID(docId, email);
       return repls;
     } catch (e) {
       return console.error(e);

--- a/packages/common/frontend/store/modules/reply.ts
+++ b/packages/common/frontend/store/modules/reply.ts
@@ -1,4 +1,4 @@
-import { createReply, getReplsByDocID } from '../../apis/';
+import { createReply, getReplsByDocID, toggleLikes } from '../../apis/';
 
 const state = {};
 
@@ -30,6 +30,15 @@ const actions = {
     try {
       const repls = await getReplsByDocID(docId, email);
       return repls;
+    } catch (e) {
+      return console.error(e);
+    }
+  },
+
+  toggleLikesAction: (_, replId: string) => {
+    if (!replId) return false;
+    try {
+      toggleLikes(replId);
     } catch (e) {
       return console.error(e);
     }

--- a/packages/wiii/frontend/components/organisms/MarketList.vue
+++ b/packages/wiii/frontend/components/organisms/MarketList.vue
@@ -1,5 +1,5 @@
 <template>
-  <section id="market-list">
+  <section id="market-list" :class="{ loading: !hasTickers }">
     <Card v-for="{ typeName, ticker, tickerName } in tickers" :key="ticker" v-bind="{ typeName, ticker, tickerName }" />
   </section>
 </template>
@@ -20,11 +20,23 @@ export default Vue.extend({
       required: true,
     },
   },
+
+  computed: {
+    hasTickers() {
+      return this.tickers.length;
+    },
+  },
 });
 </script>
 
 <style lang="scss" scoped>
 #market-list {
-  width: 100%;
+  width: 95%;
+  padding: 10px;
+  margin: 15px 0;
+  min-height: 300px;
+
+  border-radius: $border-radius-10;
+  box-shadow: 0 0 5px 0 $grey-500;
 }
 </style>

--- a/packages/wiii/frontend/components/organisms/ReplySection.vue
+++ b/packages/wiii/frontend/components/organisms/ReplySection.vue
@@ -44,22 +44,22 @@ export default Vue.extend({
   },
 
   async mounted() {
-    this.sortText = this.sortTexts[this.sortIdx];
     this.repls = await this.getReplsByDocID(this.ticker);
   },
 
   methods: {
     ...mapActions(['getRandomRepls', 'getReplsByDocID']),
 
-    async getRandRepls() {
-      try {
-        const result = await this.getRandomRepls();
-        if (!result?.length) throw new Error('No Result');
-        return result;
-      } catch (e) {
-        console.error(e);
-      }
-    },
+    /** @deprecated 개발용 더미데이터 */
+    // async getRandRepls() {
+    //   try {
+    //     const result = await this.getRandomRepls();
+    //     if (!result?.length) throw new Error('No Result');
+    //     return result;
+    //   } catch (e) {
+    //     console.error(e);
+    //   }
+    // },
 
     changeSort() {
       this.sortIdx = (this.sortIdx + 1) % 2;

--- a/packages/wiii/frontend/components/organisms/ReplySection.vue
+++ b/packages/wiii/frontend/components/organisms/ReplySection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="section">
+  <section class="section" :class="{ loading: isLoading }">
     <ReplySort @change-sort="changeSort" :sortText="sortText" />
     <ReplyInput v-bind="{ curInputId }" @change-current-input="changeCurInput" @after-submit="afterSubmit" />
     <Card
@@ -36,6 +36,7 @@ export default Vue.extend({
     const sortTexts = ['최신순', '좋아요순'];
     return {
       repls: [],
+      isLoading: true,
       sortIdx: 0,
       sortText: sortTexts[0],
       sortTexts,
@@ -45,6 +46,7 @@ export default Vue.extend({
 
   async mounted() {
     this.repls = await this.getReplsByDocID(this.ticker);
+    this.isLoading = false;
   },
 
   methods: {

--- a/packages/wiii/frontend/components/organisms/StockDetailHeader.vue
+++ b/packages/wiii/frontend/components/organisms/StockDetailHeader.vue
@@ -86,4 +86,8 @@ export default Vue.extend({
 .same {
   color: $grey-500;
 }
+
+img {
+  border-radius: 100%;
+}
 </style>

--- a/packages/wiii/frontend/styles/index.scss
+++ b/packages/wiii/frontend/styles/index.scss
@@ -41,3 +41,33 @@ body {
     }
   }
 }
+
+.loading {
+  position: relative;
+  &:before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    border-radius: $border-radius-10;
+    background: linear-gradient(45deg, $grey-300, $grey-500);
+    background-size: 300% 300%;
+    animation: gradient 5s ease-in-out infinite;
+  }
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0% 0%;
+  }
+
+  50% {
+    background-position: 100% 0%;
+  }
+
+  100% {
+    background-position: 0% 0%;
+  }
+}


### PR DESCRIPTION
- 대댓글 기능은 일단 삭제, 시간 남으면 진행 예정
- 댓글 컴포넌트에 docId, email props로 넘겨야 함

## TODO

- 좋아요 기능 BE service 수정하려고 했으나
  - User schema 연동하기 어려워서 일단 보류
  - 참고: https://github.com/zuminternet/investing-app-clone/blob/develop/packages/wiii/backend/service/Reply.service.ts
  - 댓글 목록 조회 시에도 로그인한 사용자가 좋아요 누른 댓글인지 비교해야 함
  - 좋아요 토글링할 경우에도 해당 사용자 모델 업데이트 해야함 