### PR TITLE
Feat: 뉴스 페이지 UI 수정, 모달 상세보기 추가, 종목 상세페이지 뉴스 리스트 추가

### DIFF
--- a/packages/wiii/backend/service/News.service.ts
+++ b/packages/wiii/backend/service/News.service.ts
@@ -3,6 +3,7 @@ import { Service } from 'zum-portal-core/backend/decorator/Alias';
 import { getCompanyNews, getMarketNews } from './news';
 import { marketEnum } from '../../domain/newsData';
 import { Caching } from 'zum-portal-core/backend/decorator/Caching';
+import tickerMap from './tickerMap';
 
 @Service()
 export class NewsService {
@@ -36,6 +37,7 @@ export class NewsService {
   })
   public getCompanyNewsList(symbol: string, from?: string, to?: string) {
     const now = new Date().getTime();
+    if (symbol in tickerMap) symbol = tickerMap[symbol];
     return getCompanyNews(symbol, from ?? getDateString(now - WEEK_ONE * 2), to ?? getDateString(now));
   }
 }

--- a/packages/wiii/backend/service/chart/KRXList.ts
+++ b/packages/wiii/backend/service/chart/KRXList.ts
@@ -1,5 +1,6 @@
 export default [
   { ticker: '005930', tickerName: '삼성전자' },
+  { ticker: '000660', tickerName: 'SK Hynix' },
   { ticker: '017670', tickerName: 'SK Telecom' },
   { ticker: '035420', tickerName: 'Naver' },
   { ticker: '035720', tickerName: '카카오' },

--- a/packages/wiii/backend/service/news/index.ts
+++ b/packages/wiii/backend/service/news/index.ts
@@ -15,7 +15,6 @@ import { FinnhubConfigs } from '../../config/market';
 
 const { BASE } = FinnhubConfigs;
 
-const setUrl = (paths: string[]) => `${BASE}${paths.join('/')}`;
 const setAxiosConfig = (params: object): AxiosRequestConfig => ({
   maxRedirects: 1,
   responseType: 'json',

--- a/packages/wiii/backend/service/tickerMap.ts
+++ b/packages/wiii/backend/service/tickerMap.ts
@@ -1,0 +1,31 @@
+/**
+ * 뉴스 API 등 한국주식 API 없는 경우 미국주식으로 대체
+ */
+export default {
+  /** 삼성전자 : Apple */
+  '005930': 'AAPL',
+  /** SK Hynix: Micron Tech. */
+  '000660': 'MU',
+  /** SK Telecom : Verizon */
+  '017670': 'VZ',
+  /** Naver : Google */
+  '035420': 'GOOGL',
+  /** 카카오: FaceBook */
+  '035720': 'FB',
+  /** 셀트리온: PFIZER */
+  '068270': 'PFE',
+  /** 삼성바이오: Johnson & Johnson */
+  '207940': 'JNJ',
+  /** 신풍제약: Moderna */
+  '019170': 'MRNA',
+  /** 에이프로젠 KIC: Novocure*/
+  '007460': 'NVCR',
+  /** 하이브: Warner Music Group */
+  '352820': 'WMG',
+  /** 진흥기업: Linde PLC */
+  '002780': 'LIN',
+  /** NHN: Activision Blizzard */
+  '181710': 'ATVI',
+  /** 다우기술: VeriSign */
+  '023590': 'VRSN',
+};

--- a/packages/wiii/frontend/components/atoms/Words.vue
+++ b/packages/wiii/frontend/components/atoms/Words.vue
@@ -36,7 +36,7 @@ export default Vue.extend({});
   }
 
   &.mini {
-    width: fit-content;
+    width: max-content;
     font-size: 0.6rem;
     line-height: 1.3;
     font-style: oblique;

--- a/packages/wiii/frontend/components/molecules/News.Company.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.Company.Card.vue
@@ -6,6 +6,7 @@
       <div class="news-company-card-tags noselect">
         <Words class="news-company-card-tag news-company-card-source"> {{ source }} </Words>
         <Words class="news-company-card-tag news-company-card-date">{{ dateString }} </Words>
+        <Words class="news-company-card-tag news-company-card-likes" :class="{ userLiked }"> 🏷️ {{ likes }} </Words>
       </div>
     </div>
   </article>
@@ -52,6 +53,15 @@ export default Vue.extend({
     },
     url: {
       type: String,
+      default: '',
+    },
+    likes: {
+      type: Number,
+      default: 0,
+    },
+    userLiked: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -69,7 +79,8 @@ export default Vue.extend({
   &.card {
     width: 100%;
     padding: 20px;
-    height: max-content;
+    height: fit-content;
+    max-height: 200px;
     display: grid;
     grid-template-columns: 160px auto;
     column-gap: 15px;
@@ -94,7 +105,7 @@ export default Vue.extend({
 
   &-title {
     font-weight: bold;
-    font-size: 1.2rem;
+    font-size: 1rem;
     text-align: left;
     cursor: pointer;
 
@@ -116,6 +127,7 @@ export default Vue.extend({
     overflow: visible;
     border-radius: $border-radius-10;
     font-size: 0.8rem;
+    line-height: 1.1rem;
     color: $grey-300;
     cursor: pointer;
   }
@@ -126,6 +138,19 @@ export default Vue.extend({
 
   &-date {
     background-color: $grey-700;
+  }
+
+  &-likes {
+    color: $grey-700;
+    background-color: rgba($grey-500, 0.2);
+
+    .dark & {
+      color: $grey-300;
+    }
+
+    &.userLiked {
+      background-color: rgba($red-a400, 0.4);
+    }
   }
 }
 </style>

--- a/packages/wiii/frontend/components/molecules/News.Company.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.Company.Card.vue
@@ -1,0 +1,131 @@
+<template>
+  <article class="news-company-card card" :data-id="idx">
+    <LazyImages :src="image" :alt="''" class="news-company-card-thumbnail" />
+    <div class="news-company-card-texts">
+      <Words class="news-company-card-title">{{ headline }} </Words>
+      <div class="news-company-card-tags noselect">
+        <Words class="news-company-card-tag news-company-card-source"> {{ source }} </Words>
+        <Words class="news-company-card-tag news-company-card-date">{{ dateString }} </Words>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Words from '@/components/atoms/Words.vue';
+import LazyImages from '@/components/atoms/LazyImages.vue';
+import Card from '@/components/molecules/Card.vue';
+import { getDateString } from '../../../domain/date';
+
+export default Vue.extend({
+  name: 'NewsCompanyCard',
+
+  components: { Words, Card, LazyImages },
+
+  props: {
+    id: {
+      type: Number,
+      required: true,
+    },
+    idx: {
+      type: Number,
+      required: true,
+    },
+    headline: {
+      type: String,
+      required: true,
+    },
+    image: {
+      type: String,
+    },
+    source: {
+      type: String,
+      default: '',
+    },
+    summary: {
+      type: String,
+      default: '',
+    },
+    datetime: {
+      type: Number,
+    },
+    url: {
+      type: String,
+    },
+  },
+
+  computed: {
+    dateString() {
+      /** datetime; UNIX timestamp 이므로 1_000 곱해줘야 함 */
+      return getDateString(this.datetime * 1000);
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.news-company-card {
+  &.card {
+    width: 100%;
+    padding: 20px;
+    height: max-content;
+    display: grid;
+    grid-template-columns: 160px auto;
+    column-gap: 15px;
+  }
+
+  &-thumbnail {
+    width: 100%;
+    border-radius: $border-radius-10;
+    box-shadow: 0 0 5px 0 $grey-500;
+  }
+
+  &-texts {
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    margin: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  &-title {
+    font-weight: bold;
+    font-size: 1.2rem;
+    text-align: left;
+    cursor: pointer;
+
+    .dark & {
+      color: rgba($neon-green, 0.6);
+    }
+  }
+
+  &-tags {
+    padding-top: 10px;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &-tag {
+    padding: 0 10px;
+    width: max-content;
+    overflow: visible;
+    border-radius: $border-radius-10;
+    font-size: 0.8rem;
+    color: $grey-300;
+    cursor: pointer;
+  }
+
+  &-source {
+    background-color: $shallow-blue;
+  }
+
+  &-date {
+    background-color: $grey-700;
+  }
+}
+</style>

--- a/packages/wiii/frontend/components/molecules/News.Company.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.Company.Card.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   &.card {
     width: 100%;
     padding: 20px;
-    height: fit-content;
+    height: max-content;
     max-height: 200px;
     display: grid;
     grid-template-columns: 160px auto;

--- a/packages/wiii/frontend/components/molecules/News.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.List.Card.vue
@@ -1,12 +1,13 @@
 <template>
-  <article class="card news-list-card">
-    <Words>{{ category }} </Words>
-    <LazyImages :src="image" :alt="headline" class="news-list-card-thumbnail" />
+  <article class="news-list-card card">
     <Words class="news-list-card-title">{{ headline }} </Words>
-    <Words>{{ summary }} </Words>
-    <Words>{{ url }} </Words>
-    <Words>{{ source }} </Words>
-    <Words>{{ dateString }} </Words>
+    <LazyImages :src="image" :alt="headline" class="news-list-card-thumbnail" />
+    <Words class="news-list-card-summary">{{ summary }} </Words>
+    <div class="news-list-card-tags noselect">
+      <Words class="news-list-card-tag news-list-card-category" :class="categoryColor"> {{ category.toUpperCase() }} </Words>
+      <Words class="news-list-card-tag news-list-card-source"> {{ source }} </Words>
+      <Words class="news-list-card-tag news-list-card-date">{{ dateString }} </Words>
+    </div>
   </article>
 </template>
 
@@ -17,6 +18,11 @@ import LazyImages from '@/components/atoms/LazyImages.vue';
 import Card from '@/components/molecules/Card.vue';
 import { getDateString } from '../../../domain/date';
 
+const categoryColors = {
+  'top news': 'top',
+  business: 'business',
+};
+
 export default Vue.extend({
   name: 'NewsListCard',
 
@@ -25,21 +31,26 @@ export default Vue.extend({
   props: {
     id: {
       type: Number,
+      required: true,
     },
     category: {
       type: String,
+      default: '',
     },
     headline: {
       type: String,
+      required: true,
     },
     image: {
       type: String,
     },
     source: {
       type: String,
+      default: '',
     },
     summary: {
       type: String,
+      default: '',
     },
     datetime: {
       type: Number,
@@ -54,12 +65,24 @@ export default Vue.extend({
       /** datetime; UNIX timestamp 이므로 1_000 곱해줘야 함 */
       return getDateString(this.datetime * 1000);
     },
+
+    categoryColor() {
+      return categoryColors[this.category];
+    },
   },
 });
 </script>
 
 <style lang="scss" scoped>
 .news-list-card {
+  &.card {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 10px;
+  }
+
   &-title {
     font-weight: bold;
     font-size: 1.2rem;
@@ -67,13 +90,48 @@ export default Vue.extend({
 
   &-thumbnail {
     width: 100%;
-    margin: 10px;
+    margin: 10px 0;
     border-radius: $border-radius-10;
 
     .loading {
       min-width: 100px;
       min-height: 100px;
     }
+  }
+
+  &-tags {
+    padding-top: 15px;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &-tag {
+    width: max-content;
+    overflow: visible;
+    padding: 0 10px;
+    border-radius: $border-radius-10;
+    font-size: 0.8rem;
+    color: $grey-300;
+    cursor: default;
+  }
+
+  &-category {
+    &.top {
+      background-color: $blue-900;
+    }
+
+    &.business {
+      background-color: $red-700;
+    }
+  }
+
+  &-source {
+    background-color: $shallow-blue;
+  }
+
+  &-date {
+    background-color: $grey-700;
   }
 }
 </style>

--- a/packages/wiii/frontend/components/molecules/News.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.List.Card.vue
@@ -6,6 +6,7 @@
       <Words class="news-list-card-tag news-list-card-category" :class="categoryColor"> {{ category.toUpperCase() }} </Words>
       <Words class="news-list-card-tag news-list-card-source"> {{ source }} </Words>
       <Words class="news-list-card-tag news-list-card-date">{{ dateString }} </Words>
+      <Words class="news-list-card-tag news-list-card-likes" :class="{ userLiked }"> 🏷️ {{ likes }} </Words>
     </div>
   </article>
 </template>
@@ -60,6 +61,14 @@ export default Vue.extend({
     },
     url: {
       type: String,
+    },
+    likes: {
+      type: Number,
+      default: 0,
+    },
+    userLiked: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -120,6 +129,7 @@ export default Vue.extend({
     overflow: visible;
     border-radius: $border-radius-10;
     font-size: 0.8rem;
+    line-height: 1.1rem;
     color: $grey-300;
     cursor: default;
   }
@@ -140,6 +150,19 @@ export default Vue.extend({
 
   &-date {
     background-color: $grey-700;
+  }
+
+  &-likes {
+    color: $grey-700;
+    background-color: rgba($grey-500, 0.2);
+
+    .dark & {
+      color: $grey-300;
+    }
+
+    &.userLiked {
+      background-color: rgba($red-a400, 0.4);
+    }
   }
 }
 </style>

--- a/packages/wiii/frontend/components/molecules/News.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.List.Card.vue
@@ -1,8 +1,7 @@
 <template>
-  <article class="news-list-card card">
+  <article class="news-list-card card" :data-id="idx">
     <Words class="news-list-card-title">{{ headline }} </Words>
     <LazyImages :src="image" :alt="headline" class="news-list-card-thumbnail" />
-    <Words class="news-list-card-summary">{{ summary }} </Words>
     <div class="news-list-card-tags noselect">
       <Words class="news-list-card-tag news-list-card-category" :class="categoryColor"> {{ category.toUpperCase() }} </Words>
       <Words class="news-list-card-tag news-list-card-source"> {{ source }} </Words>
@@ -30,6 +29,10 @@ export default Vue.extend({
 
   props: {
     id: {
+      type: Number,
+      required: true,
+    },
+    idx: {
       type: Number,
       required: true,
     },
@@ -86,11 +89,15 @@ export default Vue.extend({
   &-title {
     font-weight: bold;
     font-size: 1.2rem;
+
+    .dark & {
+      color: rgba($neon-green, 0.6);
+    }
   }
 
   &-thumbnail {
-    width: 100%;
-    margin: 10px 0;
+    width: 85%;
+    margin: 10px auto;
     border-radius: $border-radius-10;
 
     .loading {
@@ -100,16 +107,16 @@ export default Vue.extend({
   }
 
   &-tags {
-    padding-top: 15px;
+    padding-top: 10px;
     width: 100%;
     display: flex;
     justify-content: flex-end;
   }
 
   &-tag {
+    padding: 0 10px;
     width: max-content;
     overflow: visible;
-    padding: 0 10px;
     border-radius: $border-radius-10;
     font-size: 0.8rem;
     color: $grey-300;

--- a/packages/wiii/frontend/components/molecules/News.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/News.List.Card.vue
@@ -99,6 +99,7 @@ export default Vue.extend({
     width: 85%;
     margin: 10px auto;
     border-radius: $border-radius-10;
+    box-shadow: 0 0 5px 0 $grey-500;
 
     .loading {
       min-width: 100px;

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -6,24 +6,26 @@
       <Words id="news-modal-detail-headline">{{ headline }}</Words>
       <Words id="news-modal-detail-summary">{{ summary }}</Words>
       <Words @click.native="openOrigin" id="news-modal-detail-origin"> 원문보기 ➡️ {{ source }} </Words>
+      <Reply />
     </article>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { createNamespacedHelpers } from 'vuex';
-import { StoreNames } from '@/store';
+import { mapActions, createNamespacedHelpers } from 'vuex';
+import { RootActions, StoreNames } from '@/store';
 
 import Button from '@/components/atoms/Button.vue';
 import Words from '@/components/atoms/Words.vue';
+import Reply from '@/components/organisms/ReplySection.vue';
 
 const { mapState } = createNamespacedHelpers(StoreNames.News);
 
 export default Vue.extend({
   name: 'NewsModal',
 
-  components: { Words, Button },
+  components: { Words, Button, Reply },
 
   data() {
     return {
@@ -44,6 +46,7 @@ export default Vue.extend({
   watch: {
     currentModalNews() {
       const { id, headline, image, summary, source, url, datetime } = this.currentModalNews;
+      if (!id) return;
 
       this.id = id;
       this.headline = headline;
@@ -52,10 +55,14 @@ export default Vue.extend({
       this.source = source;
       this.url = url;
       this.datetime = datetime;
+
+      this[RootActions.SET_CURRENT_TICKER](id?.toString());
     },
   },
 
   methods: {
+    ...mapActions([RootActions.SET_CURRENT_TICKER]),
+
     openOrigin() {
       window.open(this.url);
     },
@@ -72,6 +79,7 @@ export default Vue.extend({
   left: 0;
   z-index: 10;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   background-color: rgba($grey-900, 0.8);
@@ -80,12 +88,15 @@ export default Vue.extend({
     position: relative;
     padding: 30px;
     width: 60%;
+    max-width: $max-width-mobile;
     height: max-content;
-    min-height: 400px;
+    max-height: 600px;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
+    overflow-y: auto;
+    overflow-x: hidden;
     background-color: $grey-300;
     border-radius: $border-radius-10;
     box-shadow: 0 0 5px 0 rgba($grey-700, 0.7);

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -1,11 +1,11 @@
 <template>
-  <div id="news-modal" @click="$emit('set-modal-handler')">
+  <div id="news-modal" @click.self="$emit('set-modal-handler')">
     <article id="news-modal-detail">
+      <Button id="news-modal-detail-close" @click.native="$emit('set-modal-handler')">❌</Button>
       <img :src="image" :alt="image" id="news-modal-detail-image" />
       <Words id="news-modal-detail-headline">{{ headline }}</Words>
       <Words id="news-modal-detail-summary">{{ summary }}</Words>
-      <Words id="news-modal-detail-source">{{ source }}</Words>
-      <Words @click.native="openOrigin" id="news-modal-detail-origin">원문보기</Words>
+      <Words @click.native="openOrigin" id="news-modal-detail-origin"> 원문보기 ➡️ {{ source }} </Words>
     </article>
   </div>
 </template>
@@ -13,16 +13,17 @@
 <script lang="ts">
 import Vue from 'vue';
 import { createNamespacedHelpers } from 'vuex';
-
-import Words from '@/components/atoms/Words.vue';
 import { StoreNames } from '@/store';
+
+import Button from '@/components/atoms/Button.vue';
+import Words from '@/components/atoms/Words.vue';
 
 const { mapState } = createNamespacedHelpers(StoreNames.News);
 
 export default Vue.extend({
   name: 'NewsModal',
 
-  components: { Words },
+  components: { Words, Button },
 
   data() {
     return {
@@ -76,6 +77,7 @@ export default Vue.extend({
   background-color: rgba($grey-900, 0.8);
 
   &-detail {
+    position: relative;
     padding: 30px;
     width: 80%;
     height: max-content;
@@ -86,15 +88,67 @@ export default Vue.extend({
     align-items: center;
     background-color: $grey-300;
     border-radius: $border-radius-10;
+    animation: showUp 0.3s ease-in-out;
+
+    &-close {
+      position: absolute;
+      top: 30px;
+      right: 25px;
+      width: max-content;
+      padding: 5px 10px;
+      margin-bottom: 15px;
+      cursor: pointer;
+      background-color: transparent;
+
+      &:hover {
+        color: $grey-100;
+        text-decoration: none;
+        scale: 1.25;
+      }
+    }
 
     &-image {
       width: 80%;
+      border-radius: $border-radius-10;
+      box-shadow: 0 0 10px 0 rgba($grey-700, 0.7);
     }
 
     &-headline {
+      margin: $margin-padding-15;
       font-weight: bold;
       font-size: 1.2rem;
     }
+
+    &-summary {
+      margin-bottom: $margin-padding-15;
+    }
+
+    &-origin {
+      width: max-content;
+      padding: 5px 10px;
+      cursor: pointer;
+      border-radius: $border-radius-10;
+      box-shadow: 0 0 3px 0 $grey-500;
+      font-size: 0.8rem;
+      font-weight: bold;
+      transition: all 0.1s ease-in-out;
+
+      &:hover {
+        background-color: $green-700;
+        color: $grey-100;
+        scale: 1.1;
+      }
+    }
+  }
+}
+
+@keyframes showUp {
+  0% {
+    transform: scale(0);
+  }
+
+  100% {
+    transform: scale(1);
   }
 }
 </style>

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -88,7 +88,12 @@ export default Vue.extend({
     align-items: center;
     background-color: $grey-300;
     border-radius: $border-radius-10;
+    box-shadow: 0 0 5px 0 rgba($grey-700, 0.7);
     animation: showUp 0.3s ease-in-out;
+
+    .dark & {
+      background-color: $deep-dark;
+    }
 
     &-close {
       position: absolute;
@@ -117,10 +122,18 @@ export default Vue.extend({
       margin: $margin-padding-15;
       font-weight: bold;
       font-size: 1.2rem;
+
+      .dark & {
+        color: $sup-beige;
+      }
     }
 
     &-summary {
       margin-bottom: $margin-padding-15;
+
+      .dark & {
+        color: $grey-300;
+      }
     }
 
     &-origin {
@@ -137,6 +150,14 @@ export default Vue.extend({
         background-color: $green-700;
         color: $grey-100;
         scale: 1.1;
+
+        .dark & {
+          background-color: $deep-blue;
+        }
+      }
+
+      .dark & {
+        color: $grey-500;
       }
     }
   }

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -1,0 +1,100 @@
+<template>
+  <div id="news-modal" @click="$emit('set-modal-handler')">
+    <article id="news-modal-detail">
+      <img :src="image" :alt="image" id="news-modal-detail-image" />
+      <Words id="news-modal-detail-headline">{{ headline }}</Words>
+      <Words id="news-modal-detail-summary">{{ summary }}</Words>
+      <Words id="news-modal-detail-source">{{ source }}</Words>
+      <Words @click.native="openOrigin" id="news-modal-detail-origin">원문보기</Words>
+    </article>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { createNamespacedHelpers } from 'vuex';
+
+import Words from '@/components/atoms/Words.vue';
+import { StoreNames } from '@/store';
+
+const { mapState } = createNamespacedHelpers(StoreNames.News);
+
+export default Vue.extend({
+  name: 'NewsModal',
+
+  components: { Words },
+
+  data() {
+    return {
+      id: undefined,
+      headline: undefined,
+      image: undefined,
+      summary: undefined,
+      source: undefined,
+      url: undefined,
+      datetime: undefined,
+    };
+  },
+
+  computed: {
+    ...mapState(['currentModalNews']),
+  },
+
+  watch: {
+    currentModalNews() {
+      const { id, headline, image, summary, source, url, datetime } = this.currentModalNews;
+
+      this.id = id;
+      this.headline = headline;
+      this.image = image;
+      this.summary = summary;
+      this.source = source;
+      this.url = url;
+      this.datetime = datetime;
+    },
+  },
+
+  methods: {
+    openOrigin() {
+      window.open(this.url);
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+#news-modal {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba($grey-900, 0.8);
+
+  &-detail {
+    padding: 30px;
+    width: 80%;
+    height: max-content;
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: $grey-300;
+    border-radius: $border-radius-10;
+
+    &-image {
+      width: 80%;
+    }
+
+    &-headline {
+      font-weight: bold;
+      font-size: 1.2rem;
+    }
+  }
+}
+</style>

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -5,7 +5,10 @@
       <img :src="image" :alt="image" id="news-modal-detail-image" />
       <Words id="news-modal-detail-headline">{{ headline }}</Words>
       <Words id="news-modal-detail-summary">{{ summary === 'Content' ? '기사내용이 없습니다.' : summary }}</Words>
-      <Words @click.native="openOrigin" id="news-modal-detail-origin"> 원문보기 ➡️ {{ source }} </Words>
+      <div id="news-modal-detail-options">
+        <Words @click.native="toggleLikes" id="news-modal-detail-likes" :class="{ userLiked }"> 🏷️ {{ likes }} </Words>
+        <Words @click.native="openOrigin" id="news-modal-detail-origin"> 원문보기 ➡️ {{ source }} </Words>
+      </div>
       <Reply />
     </article>
   </div>
@@ -36,6 +39,8 @@ export default Vue.extend({
       source: undefined,
       url: undefined,
       datetime: undefined,
+      likes: 0,
+      userLiked: false,
     };
   },
 
@@ -45,7 +50,7 @@ export default Vue.extend({
 
   watch: {
     currentModalNews() {
-      const { id, headline, image, summary, source, url, datetime } = this.currentModalNews;
+      const { id, headline, image, summary, source, url, datetime, likes, userLiked } = this.currentModalNews;
       if (!id) return;
 
       this.id = id;
@@ -55,6 +60,8 @@ export default Vue.extend({
       this.source = source;
       this.url = url;
       this.datetime = datetime;
+      this.likes = likes;
+      this.userLiked = userLiked;
 
       this[RootActions.SET_CURRENT_TICKER](id?.toString());
     },
@@ -65,6 +72,12 @@ export default Vue.extend({
 
     openOrigin() {
       window.open(this.url);
+    },
+
+    toggleLikes() {
+      const { likes, userLiked } = this;
+      this.likes = likes + (userLiked ? -1 : +1);
+      this.userLiked = !userLiked;
     },
   },
 });
@@ -149,14 +162,53 @@ export default Vue.extend({
       }
     }
 
+    &-options {
+      width: 100%;
+      margin: 15px 10px;
+      display: flex;
+      justify-content: space-between;
+      align-content: center;
+      font-size: 0.8rem;
+    }
+
+    &-likes {
+      width: max-content;
+      padding: 5px 10px;
+      border-radius: $border-radius-10;
+      box-shadow: 0 0 2px 0 $red-a400;
+      background-color: transparent;
+
+      display: flex;
+      align-items: center;
+      line-height: 1rem;
+      cursor: pointer;
+
+      .dark & {
+        color: $grey-300;
+      }
+
+      &:hover {
+        background-color: rgba($red-a400, 0.4);
+        color: $grey-100;
+      }
+
+      &.userLiked {
+        background-color: rgba($red-a400, 0.4);
+        color: $red-a400;
+      }
+    }
+
     &-origin {
       width: max-content;
-      margin: 15px 0;
       padding: 5px 10px;
       cursor: pointer;
       border-radius: $border-radius-10;
       box-shadow: 0 0 3px 0 $grey-500;
+
+      display: flex;
+      align-items: center;
       font-size: 0.8rem;
+      line-height: 1rem;
       font-weight: bold;
       transition: all 0.1s ease-in-out;
 

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   &-detail {
     position: relative;
     padding: 30px;
-    width: 80%;
+    width: 60%;
     height: max-content;
     min-height: 400px;
     display: flex;

--- a/packages/wiii/frontend/components/molecules/News.Modal.vue
+++ b/packages/wiii/frontend/components/molecules/News.Modal.vue
@@ -4,7 +4,7 @@
       <Button id="news-modal-detail-close" @click.native="$emit('set-modal-handler')">❌</Button>
       <img :src="image" :alt="image" id="news-modal-detail-image" />
       <Words id="news-modal-detail-headline">{{ headline }}</Words>
-      <Words id="news-modal-detail-summary">{{ summary }}</Words>
+      <Words id="news-modal-detail-summary">{{ summary === 'Content' ? '기사내용이 없습니다.' : summary }}</Words>
       <Words @click.native="openOrigin" id="news-modal-detail-origin"> 원문보기 ➡️ {{ source }} </Words>
       <Reply />
     </article>
@@ -141,6 +141,8 @@ export default Vue.extend({
 
     &-summary {
       margin-bottom: $margin-padding-15;
+      margin: 15px 0;
+      text-align: left;
 
       .dark & {
         color: $grey-300;
@@ -149,6 +151,7 @@ export default Vue.extend({
 
     &-origin {
       width: max-content;
+      margin: 15px 0;
       padding: 5px 10px;
       cursor: pointer;
       border-radius: $border-radius-10;

--- a/packages/wiii/frontend/components/molecules/Reply.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/Reply.List.Card.vue
@@ -143,8 +143,8 @@ $maxHeight: 50px;
   }
 
   .thumbnail {
-    width: fit-content;
-    height: fit-content;
+    width: max-content;
+    height: max-content;
     max-width: $maxHeight;
     max-height: $maxHeight;
     background-position: center;

--- a/packages/wiii/frontend/components/molecules/Reply.List.Card.vue
+++ b/packages/wiii/frontend/components/molecules/Reply.List.Card.vue
@@ -133,12 +133,14 @@ $paddingTop: 5px;
 $maxHeight: 50px;
 
 .reply {
-  width: 100%;
-  padding: 3% 5%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
+  &.card {
+    width: 100%;
+    padding: 3% 5%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
 
   .thumbnail {
     width: fit-content;

--- a/packages/wiii/frontend/components/molecules/ReplyInputForm.vue
+++ b/packages/wiii/frontend/components/molecules/ReplyInputForm.vue
@@ -25,10 +25,6 @@ export default Vue.extend({
 
   components: { TextArea, Button },
 
-  mounted() {
-    console.log({ route_ticker: this.ticker });
-  },
-
   computed: {
     ...mapGetters(['getTicker']),
     ticker() {

--- a/packages/wiii/frontend/components/organisms/News.Company.List.vue
+++ b/packages/wiii/frontend/components/organisms/News.Company.List.vue
@@ -1,0 +1,110 @@
+<template>
+  <section id="news-company-list" class="section">
+    <Words class="news-company-list-subtitle">뉴스 및 분석</Words>
+    <div class="news-company-list-col" :class="{ loading }" @click="setModalOpen">
+      <Card
+        v-for="({ id, ...rest }, idx) in newsList.slice(0, 5)"
+        :key="idx"
+        v-bind="{ id, idx, ...rest }"
+        class="news-list-card"
+      />
+    </div>
+    <div>더보기</div>
+    <Modal v-show="isModalOpen" @set-modal-handler="setModalOpen" />
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapState, createNamespacedHelpers } from 'vuex';
+
+import Words from '@/components/atoms/Words.vue';
+import Card from '@/components/molecules/News.Company.Card.vue';
+import Modal from '@/components/molecules/News.Modal.vue';
+
+import { StoreNames } from '@/store';
+import { getDateString, WEEK_ONE } from '../../../domain/date';
+
+const { mapActions } = createNamespacedHelpers(StoreNames.News);
+
+const today = new Date().getTime();
+const dateFrom = getDateString(today - WEEK_ONE * 2);
+const dateTo = getDateString(today);
+
+export default Vue.extend({
+  name: 'NewsCompanyList',
+
+  components: { Words, Card, Modal },
+
+  data() {
+    return {
+      isModalOpen: false,
+      loading: true,
+      dateFrom,
+      dateTo,
+      newsList: [],
+    };
+  },
+
+  computed: {
+    ...mapState(['ticker']),
+  },
+
+  methods: {
+    ...mapActions(['setModalNewsAction', 'getCompanyNewsAction']),
+
+    resetModal() {
+      this.isModalOpen = false;
+      this.setModalNewsAction({});
+    },
+
+    setModalOpen(e) {
+      const id = e?.target?.closest('article[data-id]');
+      if (!e || !id) return this.resetModal();
+
+      this.isModalOpen = true;
+      const newsData = this.newsList[id.getAttribute('data-id')];
+      this.setModalNewsAction(newsData);
+    },
+  },
+
+  async mounted() {
+    const { ticker, dateFrom, dateTo } = this;
+    this.newsList = await this.getCompanyNewsAction({ symbol: ticker, from: dateFrom, to: dateTo });
+    this.loading = false;
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+#news-company-list.section {
+  width: 100%;
+  height: 100%;
+  padding: 5px;
+
+  .news-company-list-subtitle {
+    padding: 5px;
+    font-size: 1.1rem;
+    font-weight: bold;
+    text-align: left;
+    color: $grey-700;
+
+    .dark & {
+      color: $neon-green;
+    }
+  }
+
+  .news-company-list-col {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    width: 95%;
+    min-height: 300px;
+  }
+
+  .news-list-card {
+    width: 100%;
+  }
+}
+</style>

--- a/packages/wiii/frontend/components/organisms/News.List.vue
+++ b/packages/wiii/frontend/components/organisms/News.List.vue
@@ -1,13 +1,13 @@
 <template>
   <section id="news-main-list" class="section">
     <Words class="subtitle">{{ categoryTitle }}</Words>
-    <div class="news-main-list-cols">
+    <div class="news-main-list-cols" @click="setModalOpen">
       <li class="news-main-list-col">
         <Card
           v-for="({ id, ...rest }, idx) in newsList"
           v-show="idx % 2 === 0"
           :key="idx"
-          v-bind="{ id, ...rest }"
+          v-bind="{ id, idx, ...rest }"
           class="news-list-card"
         />
       </li>
@@ -16,24 +16,31 @@
           v-for="({ id, ...rest }, idx) in newsList"
           v-show="idx % 2 === 1"
           :key="idx"
-          v-bind="{ id, ...rest }"
+          v-bind="{ id, idx, ...rest }"
           class="news-list-card"
         />
       </li>
     </div>
+    <Modal v-show="isModalOpen" @set-modal-handler="setModalOpen" />
   </section>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { createNamespacedHelpers } from 'vuex';
+
 import Words from '@/components/atoms/Words.vue';
 import Card from '@/components/molecules/News.List.Card.vue';
+import Modal from '@/components/molecules/News.Modal.vue';
 import { marketEnum } from '../../../domain/newsData';
+import { StoreNames } from '@/store';
+
+const { mapActions } = createNamespacedHelpers(StoreNames.News);
 
 export default Vue.extend({
   name: 'NewsList',
 
-  components: { Words, Card },
+  components: { Words, Card, Modal },
 
   props: {
     newsList: {
@@ -47,9 +54,31 @@ export default Vue.extend({
     },
   },
 
+  data() {
+    return {
+      isModalOpen: false,
+    };
+  },
+
   computed: {
     categoryTitle() {
       return this.category === marketEnum.general ? '시장 뉴스' : '코인 뉴스';
+    },
+  },
+
+  methods: {
+    ...mapActions(['setModalNewsAction']),
+
+    setModalOpen(e) {
+      const id = e?.target?.closest('article[data-id]');
+      if (!e || !id) {
+        this.isModalOpen = false;
+        this.setModalNewsAction({});
+        return;
+      }
+
+      this.isModalOpen = true;
+      this.setModalNewsAction(this.newsList[id.getAttribute('data-id')]);
     },
   },
 });
@@ -57,6 +86,10 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 #news-main-list {
+  .subtitle {
+    padding-bottom: 10px;
+  }
+
   .news-main-list-cols {
     width: 100%;
     min-height: 300px;

--- a/packages/wiii/frontend/components/organisms/News.List.vue
+++ b/packages/wiii/frontend/components/organisms/News.List.vue
@@ -69,16 +69,20 @@ export default Vue.extend({
   methods: {
     ...mapActions(['setModalNewsAction']),
 
+    resetModal() {
+      this.isModalOpen = false;
+      this.setModalNewsAction({});
+      history.pushState({ data: '' }, '', './');
+    },
+
     setModalOpen(e) {
       const id = e?.target?.closest('article[data-id]');
-      if (!e || !id) {
-        this.isModalOpen = false;
-        this.setModalNewsAction({});
-        return;
-      }
+      if (!e || !id) return this.resetModal();
 
       this.isModalOpen = true;
-      this.setModalNewsAction(this.newsList[id.getAttribute('data-id')]);
+      const newsData = this.newsList[id.getAttribute('data-id')];
+      this.setModalNewsAction(newsData);
+      history.pushState({ data: newsData.id }, newsData.headline, `./${newsData.id}`);
     },
   },
 });

--- a/packages/wiii/frontend/components/organisms/ReplySection.vue
+++ b/packages/wiii/frontend/components/organisms/ReplySection.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { createNamespacedHelpers } from 'vuex';
+import { mapState, createNamespacedHelpers } from 'vuex';
 import ReplyInput from '@/components/molecules/ReplyNewInput.vue';
 import ReplySort from '@/components/molecules/ReplySort.vue';
 import Card from '@/components/molecules/Reply.List.Card.vue';
@@ -25,12 +25,6 @@ export default Vue.extend({
   name: 'ReplySection',
 
   components: { ReplyInput, ReplySort, Card },
-
-  props: {
-    ticker: {
-      type: String,
-    },
-  },
 
   data() {
     const sortTexts = ['최신순', '좋아요순'];
@@ -44,6 +38,18 @@ export default Vue.extend({
     };
   },
 
+  computed: {
+    ...mapState(['ticker']),
+  },
+
+  watch: {
+    async ticker() {
+      this.isLoading = true;
+      this.repls = await this.getReplsByDocID(this.ticker);
+      this.isLoading = false;
+    },
+  },
+
   async mounted() {
     this.repls = await this.getReplsByDocID(this.ticker);
     this.isLoading = false;
@@ -51,17 +57,6 @@ export default Vue.extend({
 
   methods: {
     ...mapActions(['getRandomRepls', 'getReplsByDocID']),
-
-    /** @deprecated 개발용 더미데이터 */
-    // async getRandRepls() {
-    //   try {
-    //     const result = await this.getRandomRepls();
-    //     if (!result?.length) throw new Error('No Result');
-    //     return result;
-    //   } catch (e) {
-    //     console.error(e);
-    //   }
-    // },
 
     changeSort() {
       this.sortIdx = (this.sortIdx + 1) % 2;

--- a/packages/wiii/frontend/components/organisms/ReplySection.vue
+++ b/packages/wiii/frontend/components/organisms/ReplySection.vue
@@ -74,3 +74,9 @@ export default Vue.extend({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+section.section {
+  padding: 5px;
+}
+</style>

--- a/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
+++ b/packages/wiii/frontend/components/templates/Markets/StocksDetail.vue
@@ -1,41 +1,40 @@
 <template>
   <div class="area">
-    <!-- 상단 시세 요약 -->
     <Header v-bind="{ ...headerInfo }" />
     <PriceSummary v-bind="{ ...priceSummary }" />
     <Chart class="card" :typeName="`stock`" :apiType="`es`" :ticker="ticker" />
 
     <CompanyInfo v-bind="{ ...companyInfo }" />
-
-    <!-- 뉴스 일부 표시 -->
-
+    <News />
     <ReplySection :ticker="ticker" />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { createNamespacedHelpers } from 'vuex';
+import { mapActions, createNamespacedHelpers } from 'vuex';
 
 import Chart from '@/components/molecules/Chart.vue';
 import Header from '@/components/organisms/StockDetailHeader.vue';
 import PriceSummary from '@/components/organisms/StockDetailPriceSummary.vue';
 import CompanyInfo from '@/components/organisms/StockDetailCompanyInfo.vue';
+import News from '@/components/organisms/News.Company.List.vue';
 import ReplySection from '@/components/organisms/ReplySection.vue';
-import { StoreNames } from '@/store';
+import { RootActions, StoreNames } from '@/store';
 
 const { mapState } = createNamespacedHelpers(StoreNames.Market);
 const phoneReplacer = (_phone: string) => {
   const phone = _phone.split('.')[0];
   const len = phone.length;
   /**
-   * 10자리: 82 2 200 1114
+   * 10자리_1: 82 2 200 1114
+   * 10자리_2: 82 1588 1114
    * 11자리_1: 82 31 200 1114
    * 11자리_2: 82 2 6100 2114
    * 12자리: 82 31 2000 1114
    */
   let phoneReg;
-  if (len === 10) phoneReg = /(82)(\d{1})(\d{3})(\d{4})/;
+  if (len === 10) phoneReg = phone[2] === '1' ? /(82)(\d{4})(\d{4})/ : /(82)(\d{1})(\d{3})(\d{4})/;
   if (len === 11) phoneReg = phone[2] === '2' ? /(82)(\d{1})(\d{4})(\d{4})/ : /(82)(\d{2})(\d{3})(\d{4})/;
   if (len === 12) phoneReg = /(82)(\d{2})(\d{4})(\d{4})/;
 
@@ -54,6 +53,7 @@ export default Vue.extend({
     PriceSummary,
     Chart,
     CompanyInfo,
+    News,
     ReplySection,
   },
 
@@ -134,6 +134,12 @@ export default Vue.extend({
       dps: dividendPerShareAnnual.toLocaleString(),
       dpsRate: dividendYieldIndicatedAnnual.toFixed(2),
     };
+
+    this[RootActions.SET_CURRENT_TICKER](ticker);
+  },
+
+  methods: {
+    ...mapActions([RootActions.SET_CURRENT_TICKER]),
   },
 });
 </script>

--- a/packages/wiii/frontend/services/news/index.ts
+++ b/packages/wiii/frontend/services/news/index.ts
@@ -14,7 +14,6 @@ const newsUrl = `/api/news`;
  */
 export const getMarketNews = async (category: marketEnum = marketEnum.general) => {
   const { data, status, statusText } = await Axios.get(`${newsUrl}/market/${category}`);
-  console.log({ data, status, statusText });
   if (status >= 400) throw Error(statusText);
   return data;
 };

--- a/packages/wiii/frontend/store/modules/News.module.ts
+++ b/packages/wiii/frontend/store/modules/News.module.ts
@@ -7,12 +7,24 @@ import { marketEnum } from '../../../domain/newsData';
 
 declare const Axios: AxiosStatic;
 
+interface NewsData {
+  id: number;
+  category: string;
+  headline: string;
+  summarty: string;
+  datetime: number;
+  image: string;
+  source: string;
+  url: string;
+}
+
 interface CachingMarketNews {
   [category: string]: any[];
 }
 
 interface NewsState {
   cachedMarketNews: CachingMarketNews;
+  currentModalNews: NewsData;
 }
 
 const News = {
@@ -22,13 +34,20 @@ const News = {
       [marketEnum.general]: [],
       [marketEnum.crypto]: [],
     },
+    currentModalNews: undefined,
   },
+
   getters: {},
+
   mutations: {
     cacheMarketNews: (state, { category, data }) => {
       state.cachedMarketNews[category] = data;
     },
+    setModalNews: (state, payload: NewsData) => {
+      state.currentModalNews = payload;
+    },
   },
+
   actions: {
     getMarketNewsAction: async ({ commit }, category: marketEnum) => {
       if (!category) return;
@@ -36,6 +55,7 @@ const News = {
         const results = await getMarketNews(category);
         commit('cacheMarketNews', { category, data: results });
 
+        console.log({ results });
         if (!results) return [];
         return results;
       } catch (e) {
@@ -53,6 +73,10 @@ const News = {
       } catch (e) {
         return console.error(e);
       }
+    },
+
+    setModalNewsAction({ commit }, payload: NewsData) {
+      commit('setModalNews', payload);
     },
 
     /** 북마크 */

--- a/packages/wiii/frontend/store/modules/Reply.module.ts
+++ b/packages/wiii/frontend/store/modules/Reply.module.ts
@@ -35,7 +35,6 @@ const Reply = {
       if (!ticker) return;
       try {
         const results = await getRepls(ticker, auth);
-        console.log({ results });
         if (!results) return;
         return results;
       } catch (e) {

--- a/packages/wiii/frontend/styles/index.scss
+++ b/packages/wiii/frontend/styles/index.scss
@@ -54,13 +54,13 @@ body {
     border-radius: $border-radius-10;
     background: linear-gradient(45deg, $grey-300, $grey-500);
     background-size: 300% 300%;
-    animation: gradient 5s ease-in-out infinite;
+    animation: gradient 3s ease-in-out infinite;
   }
 }
 
 @keyframes gradient {
   0% {
-    background-position: 0% 0%;
+    background-position: 0% 100%;
   }
 
   50% {
@@ -68,6 +68,6 @@ body {
   }
 
   100% {
-    background-position: 0% 0%;
+    background-position: 0% 100%;
   }
 }


### PR DESCRIPTION
## Feat: 뉴스 상세보기 모달 추가

![image](https://user-images.githubusercontent.com/57997672/122737255-d473ac80-d2bb-11eb-816a-4456c663d6b4.png)

뉴스 페이지 UI 수정
- thumbnail, headline, tags 만 표시

![image](https://user-images.githubusercontent.com/57997672/122737415-fa00b600-d2bb-11eb-99a3-91764af4970c.png)

뉴스 리스트에서 뉴스 카드 클릭시 모달에서 상세보기

- history 변경 추가

![image](https://user-images.githubusercontent.com/57997672/122738186-b5294f00-d2bc-11eb-9a1d-5af6c5bf1021.png)

- 다크 테마 스타일
- 댓글

## Feat: 종목 상세 페이지 내 종목 뉴스 렌더링

![image](https://user-images.githubusercontent.com/57997672/122737595-2ae0eb00-d2bc-11eb-83a7-01a1ae58f618.png)


![image](https://user-images.githubusercontent.com/57997672/122737538-1997de80-d2bc-11eb-9e7d-09d7f585a5be.png)

- slice로 5개씩 렌더링

## TODO

- 더보기 클릭으로 기사 리스트 추가